### PR TITLE
Cheaper PDAs

### DIFF
--- a/code/modules/WVM/wvm.dm
+++ b/code/modules/WVM/wvm.dm
@@ -703,8 +703,8 @@ GLOBAL_VAR_INIT(vendor_cash, 0)
 	name = "Wasteland Pip-N-Walk"
 	icon_state = "generic_idle"
 	prize_list = list(
-		new /datum/data/wasteland_equipment("Pip-boy 3000",			/obj/item/pda,																150),
-		new /datum/data/wasteland_equipment("Reprogrammable ID",	/obj/item/card/id/selfassign,												100),
+		new /datum/data/wasteland_equipment("Pip-boy 3000",			/obj/item/pda,																75),
+		new /datum/data/wasteland_equipment("Reprogrammable ID",	/obj/item/card/id/selfassign,												25),
 		new /datum/data/wasteland_equipment("E.N.H.A.N.C.E. Your Pip-boy: Reagent Scanner",	/obj/item/cartridge/chemistry,						50),
 		new /datum/data/wasteland_equipment("E.N.H.A.N.C.E. Your Pip-boy: Health Scanner",	/obj/item/cartridge/medical,						50),
 		new /datum/data/wasteland_equipment("E.N.H.A.N.C.E. Your Pip-boy: Signaler",	/obj/item/cartridge/signal,								50),


### PR DESCRIPTION
## About The Pull Request

Significantly reduces the cost of PDA/Pip-boys.  Cut the cost of a PDA from the vending machine from 150 caps to 75, and the reprogrammable IDs from 100 caps to 25. This reduces the overall cost of a functioning Pip-boy from 250 caps to 100 caps.

## Why It's Good For The Game

Communication is good for roleplay, and it can be difficult to do so over the large distances of our map. A 250 cap pricetag for convenient long-distance communication is (at least, in my eyes) excessive. It isn't very engaging roleplay to have to dig through trash piles for 25 minutes just to be able to afford a Pip-boy.

## Pre-Merge Checklist
<!-- Don't bother filling these in while creating your Pull Request, just click the checkboxes after the Pull Request is opened and you are redirected to the page. -->
- [ ] You tested this on a local server.
- [ ] This code did not runtime during testing.
- [x] You documented all of your changes.
<!-- Neither the compiler nor workflow checks are perfect at detecting runtimes and errors. It is important to test your code/feature/fix locally. -->
