### PR TITLE
not awful version of the powerfist pr

### DIFF
--- a/code/_globalvars/lists/maintenance_loot.dm
+++ b/code/_globalvars/lists/maintenance_loot.dm
@@ -483,13 +483,13 @@ GLOBAL_LIST_INIT(loot_t5_melee, list(
 	/obj/item/twohanded/chainsaw,
 	/obj/item/melee/transforming/energy/axe/protonaxe,
 	/obj/item/melee/powered/ripper,
-	/obj/item/melee/powerfist,
+	/obj/item/melee/powerfist/f13,
 	/obj/item/twohanded/sledgehammer/rockethammer,
 	/obj/item/gun/ballistic/revolver/ballisticfist,
 	/obj/item/twohanded/sledgehammer/supersledge,
 	/obj/item/shishkebabpack,
 	/obj/item/melee/unarmed/deathclawgauntlet,
-	/obj/item/melee/powerfist/moleminer
+	/obj/item/melee/powerfist/f13/moleminer
 ))
 
 GLOBAL_LIST_INIT(loot_t1_range, list(

--- a/code/game/objects/effects/spawners/f13lootdrop.dm
+++ b/code/game/objects/effects/spawners/f13lootdrop.dm
@@ -637,13 +637,13 @@
 				/obj/item/twohanded/chainsaw,
 				/obj/item/twohanded/sledgehammer/rockethammer,
 				/obj/item/melee/powered/ripper,
-				/obj/item/melee/powerfist,
+				/obj/item/melee/powerfist/f13,
 				/obj/item/melee/transforming/energy/axe/protonaxe,
 				/obj/item/gun/ballistic/revolver/ballisticfist,
 				/obj/item/twohanded/sledgehammer/supersledge,
 				/obj/item/shishkebabpack,
 				/obj/item/melee/unarmed/deathclawgauntlet,
-				/obj/item/melee/powerfist/moleminer
+				/obj/item/melee/powerfist/f13/moleminer
 				)
 
 /obj/effect/spawner/lootdrop/f13/weapon/melee/random

--- a/code/game/objects/effects/spawners/themed_loot_tables.dm
+++ b/code/game/objects/effects/spawners/themed_loot_tables.dm
@@ -323,7 +323,7 @@
 		/obj/item/gun/energy/laser/plasma/glock = 2,
 		/obj/item/gun/energy/laser/plasma = 2,
 		/obj/item/gun/energy/laser/plasma/scatter =1,
-		/obj/item/melee/powerfist/moleminer = 10,
+		/obj/item/melee/powerfist/f13/moleminer = 10,
 		/obj/item/melee/transforming/energy/axe/protonaxe = 10,
 		/obj/item/gun/ballistic/revolver/ballisticfist = 5,
 		)

--- a/code/game/objects/items/melee/f13powerfist.dm
+++ b/code/game/objects/items/melee/f13powerfist.dm
@@ -2,8 +2,8 @@
 // POWER FISTS //
 /////////////////		-Uses power (gas currently) for knockback. Heavy AP, specialized for attacking heavy armor
 
-// Power Fist			Keywords: Damage max 42, AP 0.5
-/obj/item/melee/powerfist
+// Power Fist			Throws targets. Max damage 44. Full AP.
+/obj/item/melee/powerfist/f13
 	name = "power fist"
 	desc = "A metal gauntlet with a piston-powered ram on top for that extra 'oomph' in your punch."
 	icon_state = "powerfist"
@@ -12,25 +12,58 @@
 	righthand_file = 'icons/mob/inhands/weapons/melee_righthand.dmi'
 	flags_1 = CONDUCT_1
 	attack_verb = list("whacked", "fisted", "power-punched")
-	force = 14
-	armour_penetration = 0.5
+	force = 22
 	throwforce = 10
 	throw_range = 3
 	w_class = WEIGHT_CLASS_NORMAL
 	slot_flags = ITEM_SLOT_BELT | ITEM_SLOT_GLOVES
 	var/transfer_prints = TRUE //prevents runtimes with forensics when held in glove slot
+	var/throw_distance = 1
+	attack_speed = CLICK_CD_MELEE
 
+/obj/item/melee/powerfist/f13/attackby(obj/item/W, mob/user, params)
+	if(istype(W, /obj/item/wrench))
+		switch(fisto_setting)
+			if(1)
+				fisto_setting = 2
+			if(2)
+				fisto_setting = 1
+		W.play_tool_sound(src)
+		to_chat(user, "<span class='notice'>You tweak \the [src]'s piston valve to [fisto_setting].</span>")
+		attack_speed = CLICK_CD_MELEE * fisto_setting
 
-// Goliath				Keywords: Damage max 42, AP 0.55
-/obj/item/melee/powerfist/goliath
+/obj/item/melee/powerfist/f13/updateTank(obj/item/tank/internals/thetank, removing = 0, mob/living/carbon/human/user)
+	return
+
+/obj/item/melee/powerfist/f13/attack(mob/living/target, mob/living/user, attackchain_flags = NONE)
+	if(HAS_TRAIT(user, TRAIT_PACIFISM))
+		to_chat(user, "<span class='warning'>You don't want to harm other living beings!</span>")
+		return FALSE
+	var/turf/T = get_turf(src)
+	if(!T)
+		return FALSE
+	var/totalitemdamage = target.pre_attacked_by(src, user)
+	target.apply_damage(totalitemdamage * fisto_setting, BRUTE, wound_bonus = -25*fisto_setting**2)
+	target.visible_message("<span class='danger'>[user]'s powerfist lets out a loud hiss as [user.p_they()] punch[user.p_es()] [target.name]!</span>", \
+		"<span class='userdanger'>You cry out in pain as [user]'s punch flings you backwards!</span>")
+	new /obj/effect/temp_visual/kinetic_blast(target.loc)
+	playsound(loc, 'sound/weapons/resonator_blast.ogg', 50, 1)
+	playsound(loc, 'sound/weapons/genhit2.ogg', 50, 1)
+	var/atom/throw_target = get_edge_target_turf(target, get_dir(src, get_step_away(target, src)))
+	target.throw_at(throw_target, 2 * throw_distance, 0.5 + (throw_distance / 2))
+	log_combat(user, target, "power fisted", src)
+
+// Goliath				Throws targets far. Max damage 50.
+/obj/item/melee/powerfist/f13/goliath
 	name = "Goliath"
-	desc = "Armored gauntlet with a piston-powered ram, this one is a experimental one captured and named by the Legion."
+	desc = "A massive, experimental metal gauntlet captured by the Legion. The piston-powered ram on top is designed to throw targets very, very far."
 	icon = 'icons/fallout/objects/melee/melee.dmi'
 	lefthand_file = 'icons/fallout/onmob/weapons/melee1h_lefthand.dmi'
 	righthand_file = 'icons/fallout/onmob/weapons/melee1h_righthand.dmi'
 	icon_state = "goliath"
 	item_state = "goliath"
-	armour_penetration = 0.55
+	force = 25
+	throw_distance = 3
 
 
 // Ballistic Fist			Keywords: Damage max 42, AP 0.45, Shotgun
@@ -53,8 +86,8 @@
 	var/transfer_prints = TRUE //prevents runtimes with forensics when held in glove slot
 
 
-// Mole Miner				Keywords: Damage max 42, AP 0.4, Mining
-/obj/item/melee/powerfist/moleminer
+// Mole Miner				
+/obj/item/melee/powerfist/f13/moleminer
 	name = "mole miner gauntlet"
 	desc = "A hand-held mining and cutting implement, repurposed into a deadly melee weapon.  Its name origins are a mystery..."
 	icon_state = "mole_miner_g"
@@ -62,7 +95,7 @@
 	lefthand_file = 'icons/mob/inhands/weapons/melee_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/weapons/melee_righthand.dmi'
 	flags_1 = CONDUCT_1
-	armour_penetration = 0.4
+	force = 15
 	throwforce = 10
 	throw_range = 7
 	attack_verb = list("slashed", "sliced", "torn", "ripped", "diced", "cut")

--- a/code/modules/jobs/job_types/bos.dm
+++ b/code/modules/jobs/job_types/bos.dm
@@ -399,7 +399,7 @@ Star Paladin
 	backpack_contents = list(
 		/obj/item/melee/onehanded/knife/hunting = 1,
 		/obj/item/reagent_containers/hypospray/medipen/stimpak = 2,
-		/obj/item/melee/powerfist = 1,
+		/obj/item/melee/powerfist/f13 = 1,
 		/obj/item/tank/internals/oxygen = 1,
 	)
 

--- a/code/modules/jobs/job_types/legion.dm
+++ b/code/modules/jobs/job_types/legion.dm
@@ -126,7 +126,7 @@ Weapons		Lever shotgun, Grease gun, Repeater carbines, Revolvers, simple guns al
 	suit_store = /obj/item/gun/ballistic/automatic/pistol/pistol14
 	r_pocket = /obj/item/storage/bag/money/small/legion
 	l_pocket = /obj/item/flashlight/lantern
-	r_hand = /obj/item/melee/powerfist/goliath
+	r_hand = /obj/item/melee/powerfist/f13/goliath
 	l_hand = /obj/item/tank/internals/oxygen
 	backpack = null
 	satchel = null
@@ -265,7 +265,7 @@ Weapons		Lever shotgun, Grease gun, Repeater carbines, Revolvers, simple guns al
 	head = /obj/item/clothing/head/helmet/f13/legion/centurion
 	suit_store = /obj/item/gun/ballistic/automatic/pistol/pistol14
 	backpack_contents = list(
-		/obj/item/melee/powerfist/goliath = 1,
+		/obj/item/melee/powerfist/f13/goliath = 1,
 		/obj/item/ammo_box/magazine/m14mm = 3,
 		/obj/item/tank/internals/oxygen = 1
 		)


### PR DESCRIPTION
everyone said the powerfist using gas is bad, so i got rid of it

also, whoever coded the powerfist didn't understand that AP values on it do nothing as it directly applied damage

i changed it up some. now the powerfist, rather than using gas, changes its attack delay based on setting. on setting 1, it does 25 damage, on setting 2, it does 50 damage. attackspeed is adjusted so that depending on setting, it attacks slower (to compensate for the additional damage.) it also throws you the same distance universally and this only changes depending on the type.

the centurion's powerfist, the goliath, is adjusted so that it actually throws you farther now, as opposed to the literally nothing different it did before.

basically-setting 1, normal attackspeed, 4 hit crit. setting 2, 2hit crit, 2x the attackspeed.

everyone hated the gas stuff and this is easier to tweak, also means that it's now possible just to add a displacer glove etc or adjust the distance the powerfist throws you rather than being setting dependent

## Pre-Merge Checklist
<!-- Don't bother filling these in while creating your Pull Request, just click the checkboxes after the Pull Request is opened and you are redirected to the page. -->
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
<!-- Neither the compiler nor workflow checks are perfect at detecting runtimes and errors. It is important to test your code/feature/fix locally. -->

:cl:
tweak: The powerfist no longer uses gas.
/:cl:
