### PR TITLE
an explosion pr that doesn't break

### DIFF
--- a/code/modules/mob/living/carbon/human/human_defense.dm
+++ b/code/modules/mob/living/carbon/human/human_defense.dm
@@ -310,18 +310,17 @@
 
 	switch (severity)
 		if (EXPLODE_DEVASTATE)
-			if(bomb_armor < EXPLODE_GIB_THRESHOLD) //gibs the mob if their bomb armor is lower than EXPLODE_GIB_THRESHOLD
-				/*for(var/I in contents)
+			/*if(bomb_armor < EXPLODE_GIB_THRESHOLD) //gibs the mob if their bomb armor is lower than EXPLODE_GIB_THRESHOLD
+				for(var/I in contents)
 					var/atom/A = I
 					if(!QDELETED(A))
 						A.ex_act(severity)
-				gib()*/
-				return
-			else
-				brute_loss = 150
-				var/atom/throw_target = get_edge_target_turf(src, get_dir(src, get_step_away(src, src)))
-				throw_at(throw_target, 200, 4)
-				damage_clothes(400 - bomb_armor, BRUTE, "bomb")
+				gib()
+				return*/
+			brute_loss = 150
+			var/atom/throw_target = get_edge_target_turf(src, get_dir(src, get_step_away(src, src)))
+			throw_at(throw_target, 200, 4)
+			damage_clothes(400 - bomb_armor, BRUTE, "bomb")
 
 		if (EXPLODE_HEAVY)
 			brute_loss = 60

--- a/code/modules/mob/living/carbon/human/human_defense.dm
+++ b/code/modules/mob/living/carbon/human/human_defense.dm
@@ -308,35 +308,32 @@
 	var/burn_loss = 0
 	var/bomb_armor = getarmor(null, "bomb")
 
-	//200 max knockdown for EXPLODE_HEAVY
-	//160 max knockdown for EXPLODE_LIGHT
-
 	switch (severity)
 		if (EXPLODE_DEVASTATE)
 			if(bomb_armor < EXPLODE_GIB_THRESHOLD) //gibs the mob if their bomb armor is lower than EXPLODE_GIB_THRESHOLD
-				for(var/I in contents)
+				/*for(var/I in contents)
 					var/atom/A = I
 					if(!QDELETED(A))
 						A.ex_act(severity)
-				gib()
+				gib()*/
 				return
 			else
-				brute_loss = 500
+				brute_loss = 150
 				var/atom/throw_target = get_edge_target_turf(src, get_dir(src, get_step_away(src, src)))
 				throw_at(throw_target, 200, 4)
 				damage_clothes(400 - bomb_armor, BRUTE, "bomb")
 
 		if (EXPLODE_HEAVY)
 			brute_loss = 60
-			burn_loss = 60
+			burn_loss = 40
 			if(bomb_armor)
 				brute_loss = 30*(2 - round(bomb_armor*0.01, 0.05))
 				burn_loss = brute_loss				//damage gets reduced from 120 to up to 60 combined brute+burn
 			damage_clothes(200 - bomb_armor, BRUTE, "bomb")
 			if (!istype(ears, /obj/item/clothing/ears/earmuffs))
 				adjustEarDamage(30, 120)
-			Unconscious(20)							//short amount of time for follow up attacks against elusive enemies like wizards
-			Knockdown((200 - (bomb_armor * 1.6)) / 4) 	//between ~1 and ~5 seconds of knockdown depending on bomb armor
+			var/atom/throw_target = get_edge_target_turf(src, get_dir(src, get_step_away(src, src)))
+			throw_at(throw_target, 50, 4)
 			adjustStaminaLoss(brute_loss)
 
 		if(EXPLODE_LIGHT)
@@ -346,7 +343,7 @@
 			damage_clothes(max(50 - bomb_armor, 0), BRUTE, "bomb")
 			if (!istype(ears, /obj/item/clothing/ears/earmuffs))
 				adjustEarDamage(15,60)
-			Knockdown((160 - (bomb_armor * 1.6)) / 4)		//100 bomb armor will prevent knockdown altogether
+			Knockdown((100 - (bomb_armor * 3)) / 4)		//30ish bomb armor prevents knockdown entirely
 			adjustStaminaLoss(brute_loss)
 
 	take_overall_damage(brute_loss,burn_loss)
@@ -356,7 +353,7 @@
 		var/max_limb_loss = round(4/severity) //so you don't lose four limbs at severity 3.
 		for(var/X in bodyparts)
 			var/obj/item/bodypart/BP = X
-			if(prob(50/severity) && !prob(getarmor(BP, "bomb")) && BP.body_zone != BODY_ZONE_HEAD && BP.body_zone != BODY_ZONE_CHEST)
+			if(prob(15/severity) && !prob(getarmor(BP, "bomb")) && BP.body_zone != BODY_ZONE_HEAD && BP.body_zone != BODY_ZONE_CHEST)
 				BP.brute_dam = BP.max_damage
 				BP.dismember()
 				max_limb_loss--


### PR DESCRIPTION
Explosions are less deadly and won't gib anymore. Still very deadly, but they shouldn't instakill, will rarely delimb, and will throw you from the target impact zone. They also don't KO.

This lets me PR actual bomb weapons and grenades.

## Pre-Merge Checklist
<!-- Don't bother filling these in while creating your Pull Request, just click the checkboxes after the Pull Request is opened and you are redirected to the page. -->
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
<!-- Neither the compiler nor workflow checks are perfect at detecting runtimes and errors. It is important to test your code/feature/fix locally. -->

:cl:
balance: explosions no longer gib, are less likely to delimb, and throw you from the target impact zone.
/:cl:

