### PR TITLE
Adjusted Khan slots, loadout, and timelock

### DIFF
--- a/code/modules/jobs/job_types/wasteland.dm
+++ b/code/modules/jobs/job_types/wasteland.dm
@@ -294,7 +294,7 @@ Great Khan
 	backpack_contents = list(
 		/obj/item/ammo_box/shotgun/buck=1, \
 		/obj/item/ammo_box/shotgun/bean=1, \
-		/obj/item/restraints/handcuffs=2)
+		/obj/item/restraints/legcuffs/bola/tactical=1)
 
 /datum/outfit/loadout/skirmisher
 	name = "Skirmisher"

--- a/code/modules/jobs/job_types/wasteland.dm
+++ b/code/modules/jobs/job_types/wasteland.dm
@@ -215,11 +215,13 @@ Great Khan
 	department_head = list("Captain")
 	head_announce = list("Security")
 	faction = FACTION_WASTELAND
-	total_positions = 6
-	spawn_positions = 6
+	total_positions = 8
+	spawn_positions = 8
 	description = "You are no common raider or tribal settler, for you are a Great Khan. Your ancestry is that of fierce warriors and noble chieftans, whose rites and sagas tell of blood soaked battlefields and great sacrifice for your tribe. At least, this was once the case: after the massacre at Bitter Springs by the NCR, your people have lost much of their strength - now you and many other Khans travel west of Vegas through Red Rock Canyon in the hopes of settling in the region of Yuma."
 	supervisors = "your gang leadership"
 	selection_color = "#ff915e"
+	exp_requirements = 1000
+	exp_type = EXP_TYPE_WASTELAND
 
 	outfit = /datum/outfit/job/wasteland/f13pusher
 
@@ -228,7 +230,7 @@ Great Khan
 
 	loadout_options = list(
 		/datum/outfit/loadout/enforcer,
-		/datum/outfit/loadout/brawler,
+		/datum/outfit/loadout/skirmisher,
 		)
 	matchmaking_allowed = list(
 		/datum/matchmaking_pref/friend = list(
@@ -294,12 +296,13 @@ Great Khan
 		/obj/item/ammo_box/shotgun/bean=1, \
 		/obj/item/restraints/handcuffs=2)
 
-/datum/outfit/loadout/brawler
-	name = "Brawler"
-	suit_store = /obj/item/twohanded/sledgehammer
+/datum/outfit/loadout/skirmisher
+	name = "Skirmisher"
+	r_hand = obj/item/gun/ballistic/automatic/smg/mini_uzi
 	gloves = /obj/item/melee/unarmed/brass/spiked
 	backpack_contents = list(
-		/obj/item/reagent_containers/pill/patch/healpoultice=2)
+		/obj/item/ammo_box/magazine/uzi9mm=3)
+
 
 /*
 Raider

--- a/code/modules/jobs/job_types/wasteland.dm
+++ b/code/modules/jobs/job_types/wasteland.dm
@@ -301,7 +301,7 @@ Great Khan
 	r_hand = obj/item/gun/ballistic/automatic/smg/mini_uzi
 	gloves = /obj/item/melee/unarmed/brass/spiked
 	backpack_contents = list(
-		/obj/item/ammo_box/magazine/uzi9mm=3)
+		/obj/item/ammo_box/magazine/uzim9mm=3)
 
 
 /*

--- a/code/modules/jobs/job_types/wasteland.dm
+++ b/code/modules/jobs/job_types/wasteland.dm
@@ -230,7 +230,7 @@ Great Khan
 
 	loadout_options = list(
 		/datum/outfit/loadout/enforcer,
-		/datum/outfit/loadout/skirmisher,
+		/datum/outfit/loadout/skirmisher2,
 		)
 	matchmaking_allowed = list(
 		/datum/matchmaking_pref/friend = list(
@@ -296,7 +296,7 @@ Great Khan
 		/obj/item/ammo_box/shotgun/bean=1, \
 		/obj/item/restraints/legcuffs/bola/tactical=1)
 
-/datum/outfit/loadout/skirmisher
+/datum/outfit/loadout/skirmisher2
 	name = "Skirmisher"
 	r_hand = /obj/item/gun/ballistic/automatic/smg/mini_uzi
 	gloves = /obj/item/melee/unarmed/brass/spiked

--- a/code/modules/jobs/job_types/wasteland.dm
+++ b/code/modules/jobs/job_types/wasteland.dm
@@ -298,7 +298,7 @@ Great Khan
 
 /datum/outfit/loadout/skirmisher
 	name = "Skirmisher"
-	r_hand = obj/item/gun/ballistic/automatic/smg/mini_uzi
+	r_hand = /obj/item/gun/ballistic/automatic/smg/mini_uzi
 	gloves = /obj/item/melee/unarmed/brass/spiked
 	backpack_contents = list(
 		/obj/item/ammo_box/magazine/uzim9mm=3)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

<!-- NOTE: This format is NOT REQUIRED for things like runtime fixes, code fixes and optimizations. In those instances you should try to give a description of what is being fixed or optimized but are not required to fill out the complete changelog. -->
<!-- Adjusting things like armor or weapon values for balance, while they may be 'fixes' in their own way, are not considered code fixes as described above and require the use of the Pull Request format below.-->


## About The Pull Request

- Increased slot to 8 to accommodate high pop and demand for more Khans
- Added timelock tied to Wastelander due to player unrest of new players disturbing the flow of the faction roleplay.
- Changed the Brawler loadout to Skirmisher to mirror the Den Enforcer's Hitman loadout, with variations.
- Changed Enforcer a little. Removed the two handcuffs and replaced them with a reinforced bola.

![image](https://user-images.githubusercontent.com/49745305/147713400-d889c70c-3f54-45c4-bfd6-8193570df88a.png)


<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Players have been demanding more quality of life for the faction in more slots as the faction is in high demand for the experience, however, because there is no timelock on the Great Khans, new players will disturb the roleplay experience, so a timelock is needed. The loadout change has been asked for a long time as Brawler has always been a joke loadout for the Khans. Also changed the Enforcer loadout to an old-style loadout Khans used to have that people chose that loadout for, which is mainly the bola.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Pre-Merge Checklist
<!-- Don't bother filling these in while creating your Pull Request, just click the checkboxes after the Pull Request is opened and you are redirected to the page. -->
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
<!-- Neither the compiler nor workflow checks are perfect at detecting runtimes and errors. It is important to test your code/feature/fix locally. -->


## Changelog
<!-- This is mostly optional for small Pull Requests, but if you value being credited for your work in-game be sure to fill it out. To opt-out, remove everything below including the start and end :cl: brackets. -->

<!-- If your Pull Request includes a minor single line variable edit, probably do not fill out this changelog. -->
<!-- However, if your pull request includes massive or immediately noticeable changes, briefly describe those changes in some way in this changelog. -->

:cl:
add: Added new things
del: Removed old things
tweak: tweaked a few things
code: changed some code
spellcheck: fixed a few typos
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
