### PR TITLE
Converts 'The Commissioner' Sheriff outfit into 'The Chief' outfit.

### DIFF
--- a/code/modules/clothing/head/f13factionhead.dm
+++ b/code/modules/clothing/head/f13factionhead.dm
@@ -768,10 +768,13 @@
 	icon_state = "sheriffhat"
 	armor = list("tier" = 6, "energy" = 40, "bomb" = 25, "bio" = 40, "rad" = 40, "fire" = 80, "acid" = 0)
 
-/obj/item/clothing/head/f13/town/commissioner
-	name = "commissioner's hat"
+/obj/item/clothing/head/f13/town/chief
+	name = "OPD Chief's hat"
 	desc = "(V*) A blue hat with a silver badge"
-	icon_state = "policehelm"
+	icon = 'icons/fallout/clothing/hats.dmi'
+	mob_overlay_icon = 'icons/fallout/onmob/clothes/head.dmi'
+	icon_state = "police_chief"
+	item_state = "police_chief"
 	armor = list("tier" = 5, "linebullet" = 30, "energy" = 40, "bomb" = 25, "bio" = 40, "rad" = 40, "fire" = 80, "acid" = 0)
 
 /obj/item/clothing/head/f13/det_hat_alt
@@ -977,7 +980,7 @@ obj/item/clothing/head/f13/army/beret
 //Police and State Police
 
 /obj/item/clothing/head/f13/police/officer
-	name = "Police Officer's cap"
+	name = "police officer's cap"
 	desc = "(II) A simple dark navy peaked cap, worn by police."
 	icon = 'icons/fallout/clothing/hats.dmi'
 	mob_overlay_icon = 'icons/fallout/onmob/clothes/head.dmi'
@@ -986,7 +989,7 @@ obj/item/clothing/head/f13/army/beret
 	armor = list("tier" = 2, "energy" = 10, "bomb" = 0, "bio" = 0, "rad" = 0, "fire" = 10, "acid" = 0)
 
 /obj/item/clothing/head/f13/police/sergeant
-	name = "Police campaign hat"
+	name = "police campaign hat"
 	desc = "(II) A simple dark navy campaign hat, worn by police."
 	icon = 'icons/fallout/clothing/hats.dmi'
 	mob_overlay_icon = 'icons/fallout/onmob/clothes/head.dmi'
@@ -995,7 +998,7 @@ obj/item/clothing/head/f13/army/beret
 	armor = list("tier" = 2, "energy" = 10, "bomb" = 0, "bio" = 0, "rad" = 0, "fire" = 10, "acid" = 0)
 
 /obj/item/clothing/head/f13/police/lieutenant
-	name = "Police Lieutenant's cap"
+	name = "police lieutenant's cap"
 	desc = "(II) A simple dark navy peaked cap, worn by police."
 	icon = 'icons/fallout/clothing/hats.dmi'
 	mob_overlay_icon = 'icons/fallout/onmob/clothes/head.dmi'
@@ -1004,13 +1007,22 @@ obj/item/clothing/head/f13/army/beret
 	armor = list("tier" = 2, "energy" = 10, "bomb" = 0, "bio" = 0, "rad" = 0, "fire" = 10, "acid" = 0)
 
 /obj/item/clothing/head/f13/police/chief
-	name = "Police Chief's cap"
+	name = "police chief's cap"
 	desc = "(III) A simple dark navy peaked cap, worn by police."
 	icon = 'icons/fallout/clothing/hats.dmi'
 	mob_overlay_icon = 'icons/fallout/onmob/clothes/head.dmi'
 	icon_state = "police_chief"
 	item_state = "police_chief"
 	armor = list("tier" = 3, "energy" = 10, "bomb" = 0, "bio" = 0, "rad" = 0, "fire" = 10, "acid" = 0)
+
+/obj/item/clothing/head/f13/police/trooper
+	name = "state police campaign hat"
+	desc = "(II) A gray campaign hat, worn by the State Police."
+	icon = 'icons/fallout/clothing/hats.dmi'
+	mob_overlay_icon = 'icons/fallout/onmob/clothes/head.dmi'
+	icon_state = "police_chief"
+	item_state = "police_chief"
+	armor = list("tier" = 2, "energy" = 10, "bomb" = 0, "bio" = 0, "rad" = 0, "fire" = 10, "acid" = 0)
 
 //THE GRAVEYARD
 //UNUSED or LEGACY - RETAINED IN CASE DESIRED FOR ADMIN SPAWN OR REIMPLEMENATION. MAY NOT BE EVERYTHING THAT'S UNUSED. TEST BEFORE USING

--- a/code/modules/clothing/suits/f13factionarmor.dm
+++ b/code/modules/clothing/suits/f13factionarmor.dm
@@ -613,11 +613,13 @@
 	icon_state = "towntrench_heavy"
 	armor = list("tier" = 6, "energy" = 40, "bomb" = 25, "bio" = 40, "rad" = 40, "fire" = 80, "acid" = 0)
 
-/obj/item/clothing/suit/armor/f13/town/commissioner
-	name = "commissioner's jacket"
+/obj/item/clothing/suit/armor/f13/town/chief
+	name = "OPD Chief's jacket"
 	desc = "(V*)A navy-blue jacket with blue shoulder designations, '/OPD/' stitched into one of the chest pockets, and hidden ceramic trauma plates. It has a small compartment for a holdout pistol."
-	icon_state = "warden_alt"
-	item_state = "armor"
+	icon = 'icons/fallout/clothing/suits_cosmetic.dmi'
+	mob_overlay_icon = 'icons/fallout/onmob/clothes/suit_cosmetic.dmi'
+	icon_state = "police_chief"
+	item_state = "police_chief"
 	armor = list("tier" = 5, "linebullet" = 75, "energy" = 30, "bomb" = 25, "bio" = 40, "rad" = 40, "fire" = 80, "acid" = 0)
 	pocket_storage_component_path = /datum/component/storage/concrete/pockets/small/holdout
 
@@ -744,9 +746,9 @@
 	desc = "(III) A simple dark navy jacket, worn by police."
 	icon = 'icons/fallout/clothing/suits_cosmetic.dmi'
 	mob_overlay_icon = 'icons/fallout/onmob/clothes/suit_cosmetic.dmi'
-	icon_state = "police_lieutenant"
-	item_state = "police_lieutenant"
-	armor = list("tier" = 2, "energy" = 20, "bomb" = 25, "bio" = 30, "rad" = 20, "fire" = 60, "acid" = 0)
+	icon_state = "police_chief"
+	item_state = "police_chief"
+	armor = list("tier" = 3, "energy" = 20, "bomb" = 25, "bio" = 30, "rad" = 20, "fire" = 60, "acid" = 0)
 
 //THE GRAVEYARD
 //UNUSED or LEGACY - RETAINED IN CASE DESIRED FOR ADMIN SPAWN OR REIMPLEMENATION. MAY NOT BE EVERYTHING THAT'S UNUSED. TEST BEFORE USING

--- a/code/modules/clothing/under/f13.dm
+++ b/code/modules/clothing/under/f13.dm
@@ -834,7 +834,7 @@
 //Police and State Police
 
 /obj/item/clothing/under/f13/police/officer
-	name = "Police Officer's uniform"
+	name = "police officer's uniform"
 	desc = "A classic law enforcement uniform, composed of a dark navy long sleeve shirt, dark navy pants, and a black tie."
 	icon = 'icons/fallout/clothing/uniforms.dmi'
 	mob_overlay_icon = 'icons/fallout/onmob/clothes/uniform.dmi'
@@ -842,7 +842,7 @@
 	item_state = "police_officer"
 
 /obj/item/clothing/under/f13/police/lieutenant
-	name = "Police Lieutenant's uniform"
+	name = "police lieutenant's uniform"
 	desc = "A classic law enforcement uniform, composed of a dark navy long sleeve shirt, dark navy pants, and a black tie."
 	icon = 'icons/fallout/clothing/uniforms.dmi'
 	mob_overlay_icon = 'icons/fallout/onmob/clothes/uniform.dmi'
@@ -850,7 +850,7 @@
 	item_state = "police_lieutenant"
 
 /obj/item/clothing/under/f13/police/chief
-	name = "Police Chief's uniform"
+	name = "police chief's uniform"
 	desc = "A classic law enforcement uniform, composed of a dark navy long sleeve shirt, dark navy pants, and a black tie."
 	icon = 'icons/fallout/clothing/uniforms.dmi'
 	mob_overlay_icon = 'icons/fallout/onmob/clothes/uniform.dmi'
@@ -858,7 +858,7 @@
 	item_state = "police_chief"
 
 /obj/item/clothing/under/f13/police/formal
-	name = "Police formal uniform"
+	name = "police formal uniform"
 	desc = "A formal police uniform."
 	icon = 'icons/fallout/clothing/uniforms.dmi'
 	mob_overlay_icon = 'icons/fallout/onmob/clothes/uniform.dmi'
@@ -866,7 +866,7 @@
 	item_state = "police_formal"
 
 /obj/item/clothing/under/f13/police/trooper
-	name = "State Police uniform"
+	name = "state police uniform"
 	desc = "The uniform of the State Police force, composed of a a gray long sleeve shirt, gray pants, and a black tie."
 	icon = 'icons/fallout/clothing/uniforms.dmi'
 	mob_overlay_icon = 'icons/fallout/onmob/clothes/uniform.dmi'
@@ -876,7 +876,7 @@
 //get a custom swat sprite at some point
 
 /obj/item/clothing/under/f13/police/swat
-	name = "SWAT Officer uniform"
+	name = "SWAT officer uniform"
 	desc = "A US Army combat uniform, modified for SWAT team personnel."
 	icon = 'icons/fallout/clothing/uniforms.dmi'
 	mob_overlay_icon = 'icons/fallout/onmob/clothes/uniform.dmi'

--- a/code/modules/jobs/job_types/oasis.dm
+++ b/code/modules/jobs/job_types/oasis.dm
@@ -164,7 +164,7 @@ Mayor
 
 	loadout_options = list(
 	/datum/outfit/loadout/thelaw,
-	/datum/outfit/loadout/dacommissioner,
+	/datum/outfit/loadout/thechief,
 	)
 
 	access = list(ACCESS_BAR, ACCESS_CLONING, ACCESS_GATEWAY, ACCESS_CARGO_BOT, ACCESS_MINT_VAULT, ACCESS_KITCHEN, ACCESS_MINING, ACCESS_FORENSICS_LOCKERS)
@@ -212,12 +212,12 @@ Mayor
 		/obj/item/ammo_box/m44 = 2,
 		)
 
-/datum/outfit/loadout/dacommissioner
-	name = "The Commissioner"
-	uniform = /obj/item/clothing/under/f13/detectivealt
-	suit = /obj/item/clothing/suit/armor/f13/town/commissioner
-	head = /obj/item/clothing/head/f13/town/commissioner
-	shoes = /obj/item/clothing/shoes/combat
+/datum/outfit/loadout/thechief
+	name = "The Chief"
+	uniform = /obj/item/clothing/under/f13/police/formal
+	suit = /obj/item/clothing/suit/armor/f13/town/chief
+	head = /obj/item/clothing/head/f13/town/chief
+	shoes = /obj/item/clothing/shoes/jackboots
 	r_hand = /obj/item/gun/energy/laser/aer9
 	belt = /obj/item/gun/ballistic/automatic/pistol/sig/commissioner
 	backpack_contents = list(


### PR DESCRIPTION
## About The Pull Request

See above.

I planned to do this when I created the original pull request but I never got around to it.

To summarize:

The police style outfit for the Sheriff now uses the nice, new sprites.

Also I added the State Police hat which I forgot to add during the original pull request.

## Why It's Good For The Game

Sheriffs may now actually wear the police style outfit to match their Deputies.

## Pre-Merge Checklist

- [ ] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes

## Changelog

:cl:
add: added the state police hat
tweak: turned 'the commissioner' outfit into 'the chief'
tweak: fixed a naming issue with police outfits
/:cl:
