### PR TITLE
Disables Senior Paladin

### DIFF
--- a/code/modules/jobs/job_types/bos.dm
+++ b/code/modules/jobs/job_types/bos.dm
@@ -341,8 +341,8 @@ Star Paladin
 /datum/job/bos/f13seniorpaladin
 	title = "Senior Paladin"
 	flag = F13SENIORPALADIN
-	total_positions = 1
-	spawn_positions = 1
+	total_positions = 0
+	spawn_positions = 0
 	description = "As the Chapter's senior offensive warrior, you have proven your service and dedication to the Brotherhood over your time as a Paladin. As your skills gained, however, you were deigned to be more useful as a commander and trainer. Your job is to coordinate the Paladins and ensure they work as a team, instilling discipline as you go."
 	forbids = "The Brotherhood of Steel Forbids: Unethical human experimentation. Violence beyond what is needed to accomplish Brotherhood goals, and cruel torture or experiments on the minds or bodies of prisoners."
 	enforces = "The Brotherhood of Steel Expects: Obeying the Chain That - Binds your direct superior. Collection and safeguarding of technology from the wasteland. Experimentation and research."
@@ -981,7 +981,6 @@ Off-Duty
 	id = 			/obj/item/card/id/dogtag
 	backpack_contents = list(
 		/obj/item/reagent_containers/hypospray/medipen/stimpak=1,
-		/obj/item/stack/medical/gauze=1,
 		/obj/item/encryptionkey/headset_bos=1,
 		/obj/item/melee/onehanded/knife/survival=1
 		)


### PR DESCRIPTION
## About The Pull Request

Disables the Senior Paladin slot.

## Why It's Good For The Game

Consensus seems to be that four PA roles in the Brotherhood is a little too strong, and the Paladin Caste should be able to perform effectively with two Paladins and one Head. This should alleviate the balance concerns with the Brotherhood's roundstart power level.

## Pre-Merge Checklist
- [ ] You tested this on a local server.
- [ ] This code did not runtime during testing.
- [x] You documented all of your changes.


## Changelog
:cl:
del: Disables senior paladin
del: Removes a duplicate roll of gauze from Off-Duty loadouts, since they already get one in their box.
/:cl: