### PR TITLE
Increased stunprod charge cost (nerf)

### DIFF
--- a/code/game/objects/items/stunbaton.dm
+++ b/code/game/objects/items/stunbaton.dm
@@ -284,7 +284,7 @@
 	force = 3
 	throwforce = 5
 	stamforce = 25
-	hitcost = 1000
+	hitcost = 7000
 	throw_hit_chance = 10
 	slot_flags = ITEM_SLOT_BACK
 	var/obj/item/assembly/igniter/sparkler


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

<!-- NOTE: This format is NOT REQUIRED for things like runtime fixes, code fixes and optimizations. In those instances you should try to give a description of what is being fixed or optimized but are not required to fill out the complete changelog. -->
<!-- Adjusting things like armor or weapon values for balance, while they may be 'fixes' in their own way, are not considered code fixes as described above and require the use of the Pull Request format below.-->


## About The Pull Request

Increases the hitcost var on stunprods from 1000 to 7000. With this value, the number of uses per each power cell is as follows:

Standard: Incompatible
High-Capacity: Two uses
Super-Capacity: Three uses
Hyper-Capacity: Four uses
Bluespace: Six uses

## Why It's Good For The Game

Stunprods are an easy-to-produce "I win" button for anyone who gets within close range of an enemy. Increasing the charge cost (and thereby reducing the number of times they can be used before requiring recharging/swapping cells) will make their usage more balanced without removing them entirely, as they can only be used to incapacitate one or two enemies before running out of charge.

## Pre-Merge Checklist
<!-- Don't bother filling these in while creating your Pull Request, just click the checkboxes after the Pull Request is opened and you are redirected to the page. -->
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
<!-- Neither the compiler nor workflow checks are perfect at detecting runtimes and errors. It is important to test your code/feature/fix locally. -->
