### PR TITLE
BoS Timelocks +2 Knight Slots for SK/K, Add Ripper & BPF

### DIFF
--- a/_maps/map_files/Pahrump/Pahrump-Surface-2.dmm
+++ b/_maps/map_files/Pahrump/Pahrump-Surface-2.dmm
@@ -26251,7 +26251,12 @@
 "kZV" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/fluff/broken_flooring,
-    },
+/obj/structure/ladder/unbreakable{
+	desc = "A sturdy ladder that leads down deep into the earth... don't fall.";
+	height = 2;
+	id = "digsite";
+	name = "ladder to the depths"
+	},
 /turf/open/floor/plasteel/elevatorshaft,
 /area/f13/building)
 "lae" = (

--- a/_maps/map_files/Pahrump/Pahrump-Surface-2.dmm
+++ b/_maps/map_files/Pahrump/Pahrump-Surface-2.dmm
@@ -26251,12 +26251,7 @@
 "kZV" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/fluff/broken_flooring,
-/obj/structure/ladder/unbreakable{
-	desc = "A sturdy ladder that leads down deep into the earth... don't fall.";
-	height = 2;
-	id = "digsite";
-	name = "ladder to the depths"
-	},
+    },
 /turf/open/floor/plasteel/elevatorshaft,
 /area/f13/building)
 "lae" = (

--- a/code/modules/jobs/job_types/bos.dm
+++ b/code/modules/jobs/job_types/bos.dm
@@ -891,7 +891,7 @@ Knight
 		/obj/item/ammo_box/magazine/m45exp = 2,
 		)
 
-/datum/outfit/loadout/knightde
+/datum/outfit/loadout/knighte
 	name = "Knight-Defender"
 	backpack_contents = list(
 		/obj/item/clothing/accessory/bos/knight=1,

--- a/code/modules/jobs/job_types/bos.dm
+++ b/code/modules/jobs/job_types/bos.dm
@@ -783,8 +783,8 @@ Senior Knight
 	name = "Cavalry"
 	backpack_contents = list(
 		/obj/item/clothing/accessory/bos/knight=1,
-		/obj/item/melee/powered/ripper/prewar,
-		/obj/item/shield/riot/bullet_proof,
+		/obj/item/melee/powered/ripper/prewar=1,
+		/obj/item/shield/riot/bullet_proof=1,
 		)
 /*
 Knight
@@ -876,8 +876,8 @@ Knight
 	name = "Junior Knight-Cavalry"
 	backpack_contents = list(
 		/obj/item/clothing/accessory/bos/juniorknight=1,
-		/obj/item/melee/powered/ripper/prewar,
-		/obj/item/shield/riot/bullet_proof,
+		/obj/item/melee/powered/ripper/prewar=1,
+		/obj/item/shield/riot/bullet_proof=1,
 		)
 
 
@@ -905,8 +905,8 @@ Knight
 	name = "Knight-Cavalry"
 	backpack_contents = list(
 		/obj/item/clothing/accessory/bos/knight=1,
-		/obj/item/melee/powered/ripper/prewar,
-		/obj/item/shield/riot/bullet_proof,
+		/obj/item/melee/powered/ripper/prewar=1,
+		/obj/item/shield/riot/bullet_proof=1,
 		)
 /*
 Initiate

--- a/code/modules/jobs/job_types/bos.dm
+++ b/code/modules/jobs/job_types/bos.dm
@@ -103,7 +103,7 @@ Head Paladin
 	supervisors = "the elder"
 	selection_color = "#7f8c8d"
 
-	exp_requirements = 1500
+	exp_requirements = 4800
 
 	loadout_options = list(
 	/datum/outfit/loadout/sentstand, //Tribeam laser
@@ -209,7 +209,7 @@ Head Scribe
 	supervisors = "the elder"
 	selection_color = "#7f8c8d"
 
-	exp_requirements = 1500
+	exp_requirements = 3000
 
 	loadout_options = list(
 	/datum/outfit/loadout/hsstand,
@@ -277,7 +277,7 @@ Head Knight
 	supervisors = "the elder"
 	selection_color = "#7f8c8d"
 
-	exp_requirements = 1500
+	exp_requirements = 3000
 
 	loadout_options = list(
 	/datum/outfit/loadout/capstand, //Wattz 2k
@@ -358,7 +358,7 @@ Star Paladin
 	supervisors = "the Head Paladin"
 	selection_color = "#95a5a6"
 
-	exp_requirements = 750
+	exp_requirements = 2400 //Not used right now anyways. Slot disabled.
 	exp_type = EXP_TYPE_BROTHERHOOD
 
 	loadout_options = list(
@@ -454,7 +454,7 @@ Paladin
 	enforces = "The Brotherhood of Steel Expects: Obeying the Chain That - Binds your direct superior. Collection and safeguarding of technology from the wasteland. Experimentation and research."
 	supervisors = "the Senior Paladin and Head Paladin"
 	selection_color = "#95a5a6"
-	exp_requirements = 450
+	exp_requirements = 2400
 
 	loadout_options = list(
 	/datum/outfit/loadout/paladina, //R91
@@ -565,7 +565,7 @@ Senior Scribe
 	supervisors = "the Head Scribe"
 	selection_color = "#95a5a6"
 
-	exp_requirements = 600
+	exp_requirements = 1800
 
 	outfit = /datum/outfit/job/bos/f13seniorscribe
 
@@ -626,7 +626,7 @@ Scribe
 	supervisors = "the Senior Scribe and Head Scribe"
 	selection_color = "#95a5a6"
 
-	exp_requirements = 300
+	exp_requirements = 600
 
 	loadout_options = list(
 	/datum/outfit/loadout/scribea,
@@ -696,19 +696,20 @@ Senior Knight
 /datum/job/bos/f13seniorknight
 	title = "Senior Knight"
 	flag = F13SENIORKNIGHT
-	total_positions = 1
-	spawn_positions = 1
+	total_positions = 2
+	spawn_positions = 2
 	description = "You report directly to the Head Knight. You are the Brotherhood Senior Knight. Having served the Knight Caste for some time now, you are versatile and experienced in both basic combat and repairs, and also a primary maintainer of the Bunker's facilities. As your seniormost Knight, you may be assigned initiates or Junior Knights to mentor."
 	forbids = "The Brotherhood of Steel Forbids: Unethical human experimentation. Violence beyond what is needed to accomplish Brotherhood goals, and cruel torture or experiments on the minds or bodies of prisoners."
 	enforces = "The Brotherhood of Steel Expects: Obeying the Chain That - Binds your direct superior. Collection and safeguarding of technology from the wasteland. Experimentation and research."
 	supervisors = "the Head Knight"
 	selection_color = "#95a5a6"
-	exp_requirements = 600
+	exp_requirements = 1800
 
 	loadout_options = list(
 	/datum/outfit/loadout/sknighta, //AER9
 	/datum/outfit/loadout/sknightb, //Browning Auto-5
 	/datum/outfit/loadout/sknightc, //R93 PDW
+	/datum/outfit/loadout/sknightd, //Ripper, BPF
 	)
 
 	outfit = /datum/outfit/job/bos/f13seniorknight
@@ -778,7 +779,13 @@ Senior Knight
 		/obj/item/stock_parts/cell/ammo/ec=2,
 		)
 
-
+/datum/outfit/loadout/sknightd
+	name = "Cavalry"
+	backpack_contents = list(
+		/obj/item/clothing/accessory/bos/knight=1,
+		/obj/item/melee/powered/ripper/prewar,
+		/obj/item/shield/riot/bullet_proof,
+		)
 /*
 Knight
 */
@@ -786,21 +793,23 @@ Knight
 /datum/job/bos/f13knight
 	title = "Knight"
 	flag = F13KNIGHT
-	total_positions = 3
-	spawn_positions = 3
+	total_positions = 4
+	spawn_positions = 4
 	description = " You are the Brotherhood Knight, the veritable lifeblood of your organization. You are a versatile and adaptably trained person: from your primary duties of weapon & armor repair to basic combat, survival and stealth skills, the only thing you lack is proper experience. You are also in charge of Initiates."
 	forbids = "TheBrotherhood of Steel Forbids: Unethical human experimentation. Violence beyond what is needed to accomplish Brotherhood goals, and cruel torture or experiments on the minds or bodies of prisoners."
 	enforces = "The Brotherhood of Steel Expects: Obeying the Chain That - Binds your direct superior. Collection and safeguarding of technology from the wasteland. Experimentation and research."
 	supervisors = "the Senior Knight, and Head Knight"
 	selection_color = "#95a5a6"
 
-	exp_requirements = 300
+	exp_requirements = 600
 
 	loadout_options = list(
 	/datum/outfit/loadout/knighta, //AER9
 	/datum/outfit/loadout/knightb, //R82
-	/datum/outfit/loadout/knightc,
-	/datum/outfit/loadout/knightd
+	/datum/outfit/loadout/knightc, //AER9S
+	/datum/outfit/loadout/knightd, //R82 J
+	/datum/outfit/loadout/knighte, //Ripper J
+	/datum/outfit/loadout/knightf, //Ripper S
 	)
 
 	outfit = /datum/outfit/job/bos/f13knight
@@ -862,8 +871,17 @@ Knight
 		/obj/item/gun/energy/laser/pistol=1,
 		/obj/item/stock_parts/cell/ammo/ec=2,
 		)
-
+		
 /datum/outfit/loadout/knightc
+	name = "Junior Knight-Cavalry"
+	backpack_contents = list(
+		/obj/item/clothing/accessory/bos/juniorknight=1,
+		/obj/item/melee/powered/ripper/prewar,
+		/obj/item/shield/riot/bullet_proof,
+		)
+
+
+/datum/outfit/loadout/knightd
 	name = "Footknight"
 	backpack_contents = list(
 		/obj/item/clothing/accessory/bos/knight=1,
@@ -873,7 +891,7 @@ Knight
 		/obj/item/ammo_box/magazine/m45exp = 2,
 		)
 
-/datum/outfit/loadout/knightd
+/datum/outfit/loadout/knightde
 	name = "Knight-Defender"
 	backpack_contents = list(
 		/obj/item/clothing/accessory/bos/knight=1,
@@ -881,6 +899,14 @@ Knight
 		/obj/item/ammo_box/magazine/m556/rifle=2,
 		/obj/item/gun/energy/laser/pistol=1,
 		/obj/item/stock_parts/cell/ammo/ec=2,
+		)
+
+/datum/outfit/loadout/knightf
+	name = "Knight-Cavalry"
+	backpack_contents = list(
+		/obj/item/clothing/accessory/bos/knight=1,
+		/obj/item/melee/powered/ripper/prewar,
+		/obj/item/shield/riot/bullet_proof,
 		)
 /*
 Initiate


### PR DESCRIPTION
increases BoS timelocks nicely

Knight/Scribe: 10 hours
Senior: 30 hours
Head Knight/Scribe: 50 hours
Paladin: 40 hours
Head Paladin: 80 hours


Adds Ripper & BPF to JK/K and SK. 

+1 Knight slot
+1 Senior Knight slot