### PR TITLE
hasty coconut bomb disable

### DIFF
--- a/code/modules/hydroponics/grown/misc.dm
+++ b/code/modules/hydroponics/grown/misc.dm
@@ -312,6 +312,7 @@
 		return
 
 /obj/item/reagent_containers/food/snacks/grown/coconut/attackby(obj/item/W, mob/user, params)
+	/* Coconut bombs (disabled)
 	//DEFUSING NADE LOGIC
 	if (W.tool_behaviour == TOOL_WIRECUTTER && fused)
 		user.show_message("<span class='notice'>You cut the fuse!</span>", MSG_VISUAL)
@@ -352,6 +353,7 @@
 			desc = "A makeshift bomb made out of a coconut. You estimate the fuse is long enough for 5 seconds."
 			name = "coconut bomb"
 			return
+	*/
 	//ADDING STRAW LOGIC
 	if (istype(W,/obj/item/stack/sheet/mineral/bamboo) && opened && !straw && fused)
 		user.show_message("<span class='notice'>You add a bamboo straw to the coconut!</span>", 1)
@@ -454,8 +456,10 @@
 
 /obj/item/reagent_containers/food/snacks/grown/coconut/afterattack(obj/target, mob/user, proximity)
 	. = ..()
+	/* coconut bombs disabled
 	if(fusedactive)
 		return
+	*/
 
 	if((!proximity) || !check_allowed_items(target,target_self=1))
 		return
@@ -495,6 +499,7 @@
 	. = ..()
 	transform *= TRANSFORM_USING_VARIABLE(40, 100) + 0.5 //temporary fix for size?
 
+/* coconut bombs disabled
 /obj/item/reagent_containers/food/snacks/grown/coconut/proc/prime()
 	if (defused)
 		return
@@ -512,6 +517,7 @@
 		prime()
 	if(!QDELETED(src))
 		qdel(src)
+*/
 
 /obj/item/seeds/aloe
 	name = "pack of aloe seeds"


### PR DESCRIPTION
## About The Pull Request

quick webedit to disable coconut bombs

## Why It's Good For The Game

chemistry grenades are not actually intended to be accessible to players (it just took us forever to remove this alternative method of making grenades), and now that actual explosives are in the game, these are obsolete

## Pre-Merge Checklist
<!-- Don't bother filling these in while creating your Pull Request, just click the checkboxes after the Pull Request is opened and you are redirected to the page. -->
- [ ] You tested this on a local server.
- [ ] This code did not runtime during testing.
- [ ] You documented all of your changes.
<!-- Neither the compiler nor workflow checks are perfect at detecting runtimes and errors. It is important to test your code/feature/fix locally. -->