### PR TITLE
Changes Ironfists to Big Leagues on Dead Horses.

### DIFF
--- a/code/game/objects/items/granters.dm
+++ b/code/game/objects/items/granters.dm
@@ -1053,7 +1053,7 @@
 				traitname = "Rustwalkers"
 				crafting_recipe_types = list(/datum/crafting_recipe/autoaxe, /datum/crafting_recipe/steelsaw, /datum/crafting_recipe/tools/forged/entrenching_tool, /datum/crafting_recipe/chainsaw)
 			if("Dead Horses")
-				granted_trait = TRAIT_IRONFIST
+				granted_trait = TRAIT_BIG_LEAGUES
 				traitname = "Dead Horses"
 			if("Sorrows")
 				granted_trait = TRAIT_TRAPPER


### PR DESCRIPTION

## About The Pull Request

This PR changes Dead Horses trait into Big Leagues instead of Iron Fists. I have asked the dev of the west tribals and said 'hey I accidentally didnt change the perk over' and so instead of waiting, I did it myself since someone did tell me to go do it if it is a mistake. Big Leagues was meant to be one of the pickable ones for the Dead Horses. Which if I have to be honest Big Leagues is a bit more better in terms of selection, as without it kinda nerfs this role into the ground until they get it selectable.

## Why It's Good For The Game

Big leagues was in the game for tribals before the West Tribals PR, and this adds it back into the tribals so they can pick. 

## Pre-Merge Checklist
<!-- Don't bother filling these in while creating your Pull Request, just click the checkboxes after the Pull Request is opened and you are redirected to the page. -->
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
<!-- Neither the compiler nor workflow checks are perfect at detecting runtimes and errors. It is important to test your code/feature/fix locally. -->


## Changelog

:cl:
fixes: Dead Horses to have Big leagues instead of Ironfists.
/:cl:

