### PR TITLE
Another legion loadout webedit

### DIFF
--- a/code/modules/jobs/job_types/legion.dm
+++ b/code/modules/jobs/job_types/legion.dm
@@ -431,8 +431,8 @@ commented out pending rework*/
 	suit_store = /obj/item/gun/ballistic/rifle/repeater/trail
 	backpack_contents = list(
 		/obj/item/ammo_box/tube/m44 = 2,
-		/obj/item/gun/ballistic/automatic/pistol/m1911/compact = 1,
-		/obj/item/ammo_box/magazine/m45 = 1,
+		/obj/item/gun/ballistic/revolver/colt357 = 1,
+		/obj/item/ammo_box/a357 = 1,
 		)
 
 
@@ -730,8 +730,8 @@ commented out pending rework*/
 	suit_store = /obj/item/gun/ballistic/rifle/repeater/trail
 	backpack_contents = list(
 		/obj/item/ammo_box/m44box = 1,
-		/obj/item/gun/ballistic/automatic/pistol/m1911/compact = 1,
-		/obj/item/ammo_box/magazine/m45 = 1,
+		/obj/item/gun/ballistic/revolver/colt357,
+		/obj/item/ammo_box/a357 = 1,
 		)
 
 /datum/outfit/loadout/vetberserker
@@ -799,10 +799,10 @@ commented out pending rework*/
 
 /datum/outfit/loadout/primelancer
 	name = "Frontliner"
-	suit_store = /obj/item/gun/ballistic/automatic/pistol/m1911/custom
+	suit_store = /obj/item/gun/ballistic/revolver/colt357
 	r_hand = /obj/item/shield/riot/legion
 	backpack_contents = list(
-		/obj/item/ammo_box/magazine/m45 = 3,
+		/obj/item/ammo_box/a357 = 3,
 		/obj/item/restraints/legcuffs/bola = 1,
 		/obj/item/book/granter/trait/trekking = 1,
 		)

--- a/code/modules/jobs/job_types/legion.dm
+++ b/code/modules/jobs/job_types/legion.dm
@@ -244,6 +244,7 @@ Weapons		Lever shotgun, Grease gun, Repeater carbines, Revolvers, simple guns al
 	backpack_contents = list(
 		/obj/item/restraints/legcuffs/bola = 1,
 		/obj/item/storage/bag/money/small/legion = 1,
+		/obj/item/warpaint_bowl,
 		)
 
 /datum/outfit/loadout/palacent
@@ -504,6 +505,7 @@ commented out pending rework*/
 		/obj/item/melee/onehanded/machete/forgedmachete = 1,
 		/obj/item/storage/backpack/spearquiver = 1,
 		/obj/item/melee/onehanded/knife/bayonet = 1,
+		/obj/item/warpaint_bowl,
 		)
 
 
@@ -563,6 +565,7 @@ commented out pending rework*/
 		/obj/item/restraints/handcuffs = 1,
 		/obj/item/megaphone/cornu = 1,
 		/obj/item/storage/bag/money/small/legenlisted = 1,
+		/obj/item/warpaint_bowl,
 		)
 
 /datum/outfit/loadout/vexbear

--- a/code/modules/jobs/job_types/legion.dm
+++ b/code/modules/jobs/job_types/legion.dm
@@ -721,7 +721,7 @@ commented out pending rework*/
 	suit_store = /obj/item/gun/ballistic/revolver/m29
 	backpack_contents = list(
 		/obj/item/ammo_box/m44 = 3,
-		obj/item/shield/riot/bullet_proof = 1,
+		/obj/item/shield/riot/bullet_proof = 1,
 		/obj/item/stack/crafting/armor_plate = 3,
 		)
 

--- a/code/modules/jobs/job_types/legion.dm
+++ b/code/modules/jobs/job_types/legion.dm
@@ -430,8 +430,8 @@ commented out pending rework*/
 	suit_store = /obj/item/gun/ballistic/rifle/repeater/trail
 	backpack_contents = list(
 		/obj/item/ammo_box/tube/m44 = 2,
-		/obj/item/gun/ballistic/revolver/colt6520 = 1,
-		/obj/item/ammo_box/l10mm = 1,
+		/obj/item/gun/ballistic/automatic/pistol/m1911/compact = 1,
+		/obj/item/ammo_box/magazine/m45 = 1,
 		)
 
 
@@ -651,7 +651,6 @@ commented out pending rework*/
 	suit_store = /obj/item/gun/ballistic/automatic/marksman/sniper
 	backpack_contents = list(
 		/obj/item/ammo_box/magazine/w308 = 3,
-		/obj/item/melee/onehanded/machete = 1,
 		/obj/item/grenade/smokebomb = 1,
 		)
 
@@ -711,6 +710,7 @@ commented out pending rework*/
 		/obj/item/reagent_containers/pill/patch/healingpowder = 1,
 		/obj/item/storage/bag/money/small/legenlisted = 1,
 		/obj/item/restraints/handcuffs = 1,
+		/obj/item/melee/onehanded/machete/gladius = 1,
 		)
 
 /datum/outfit/loadout/vetshielder
@@ -718,17 +718,17 @@ commented out pending rework*/
 	suit_store = /obj/item/gun/ballistic/revolver/m29
 	backpack_contents = list(
 		/obj/item/ammo_box/m44 = 3,
-		/obj/item/melee/onehanded/machete/gladius = 1,
-		/obj/item/shield/riot/legion = 1,
-		/obj/item/stack/crafting/armor_plate = 1,
+		obj/item/shield/riot/bullet_proof = 1,
+		/obj/item/stack/crafting/armor_plate = 3,
 		)
 
 /datum/outfit/loadout/vetrifle
 	name = "Sharpshooter"
 	suit_store = /obj/item/gun/ballistic/rifle/repeater/trail
 	backpack_contents = list(
-		/obj/item/ammo_box/tube/m44 = 3,
-		/obj/item/melee/onehanded/machete/gladius = 1,
+		/obj/item/ammo_box/m44box = 1,
+		/obj/item/gun/ballistic/automatic/pistol/m1911/compact = 1,
+		/obj/item/ammo_box/magazine/m45 = 1,
 		)
 
 /datum/outfit/loadout/vetberserker
@@ -791,16 +791,16 @@ commented out pending rework*/
 	backpack_contents = list(
 		/obj/item/storage/bag/money/small/legenlisted = 1,
 		/obj/item/reagent_containers/pill/patch/healingpowder = 1,
+		/obj/item/melee/onehanded/machete/forgedmachete = 1,
 		)
 
 /datum/outfit/loadout/primelancer
 	name = "Frontliner"
-	suit_store = /obj/item/gun/ballistic/automatic/pistol/n99
+	suit_store = /obj/item/gun/ballistic/automatic/pistol/m1911/custom
 	r_hand = /obj/item/shield/riot/legion
 	backpack_contents = list(
-		/obj/item/ammo_box/magazine/m10mm_adv = 2,
+		/obj/item/ammo_box/magazine/m45 = 3,
 		/obj/item/restraints/legcuffs/bola = 1,
-		/obj/item/melee/onehanded/machete/forgedmachete = 1,
 		/obj/item/book/granter/trait/trekking = 1,
 		)
 
@@ -809,7 +809,6 @@ commented out pending rework*/
 	suit_store = /obj/item/gun/ballistic/rifle/repeater/cowboy
 	backpack_contents = list(
 		/obj/item/ammo_box/a357 = 3,
-		/obj/item/melee/onehanded/machete = 1,
 		/obj/item/grenade/homemade/firebomb = 1,
 		)
 
@@ -819,7 +818,6 @@ commented out pending rework*/
 	backpack_contents = list(
 		/obj/item/ammo_box/shotgun/buck = 1,
 		/obj/item/melee/onehanded/knife/bayonet = 1,
-		/obj/item/melee/onehanded/machete = 1,
 		/obj/item/storage/backpack/spearquiver = 1,
 		)
 
@@ -869,22 +867,23 @@ commented out pending rework*/
 	backpack_contents = list(
 		/obj/item/storage/bag/money/small/legenlisted = 1,
 		/obj/item/reagent_containers/pill/patch/healingpowder = 1,
+		/obj/item/melee/onehanded/machete = 1,
 		)
 
 /datum/outfit/loadout/recruittribal
-	name = "Tribal Recruit"
+	name = "Tribal"
 	suit_store = /obj/item/twohanded/fireaxe
 	backpack_contents = list(
 		/obj/item/restraints/legcuffs/bola = 1,
 		/obj/item/book/granter/trait/trekking = 1,
+		/obj/item/warpaint_bowl
 		)
 
 /datum/outfit/loadout/recruitlegion
-	name = "Legion Recruit"
+	name = "Recruit"
 	suit_store = /obj/item/gun/ballistic/revolver/colt357
 	backpack_contents = list(
 		/obj/item/ammo_box/a357 = 3,
-		/obj/item/melee/onehanded/machete = 1,
 		/obj/item/reagent_containers/food/drinks/bottle/molotov = 2,
 		/obj/item/reagent_containers/glass/bottle/napalm = 2,
 		/obj/item/lighter/greyscale = 1,
@@ -930,6 +929,7 @@ commented out pending rework*/
 		/obj/item/razor = 1,
 		/obj/item/restraints/legcuffs/bola = 1,
 		/obj/item/electropack/shockcollar/explosive = 1,
+		/obj/item/warpaint_bowl
 		)
 
 /datum/outfit/job/CaesarsLegion/Legionnaire/f13slavemaster/post_equip(mob/living/carbon/human/H, visualsOnly = FALSE)
@@ -938,7 +938,6 @@ commented out pending rework*/
 		return
 	ADD_TRAIT(H, TRAIT_BIG_LEAGUES, src)
 	ADD_TRAIT(H, TRAIT_MARS_TEACH, src)
-
 
 // FORGE MASTER
 
@@ -1034,6 +1033,7 @@ commented out pending rework*/
 	r_pocket = /obj/item/flashlight/lantern
 	backpack_contents = list(
 		/obj/item/reagent_containers/pill/patch/healingpowder = 2,
+		/obj/item/warpaint_bowl
 		)
 
 /datum/outfit/job/CaesarsLegion/auxilia/post_equip(mob/living/carbon/human/H, visualsOnly = FALSE)
@@ -1044,6 +1044,7 @@ commented out pending rework*/
 	ADD_TRAIT(H, TRAIT_MARS_TEACH, src)
 	ADD_TRAIT(H, TRAIT_TECHNOPHREAK, src)
 	H.mind.teach_crafting_recipe(/datum/crafting_recipe/tailor/legionuniform)
+	H.mind.teach_crafting_recipe(/datum/crafting_recipe/warpaint)
 
 
 /datum/outfit/loadout/auxassist


### PR DESCRIPTION
[<!--] Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

<!-- NOTE: This format is NOT REQUIRED for things like runtime fixes, code fixes and optimizations. In those instances you should try to give a description of what is being fixed or optimized but are not required to fill out the complete changelog. -->
<!-- Adjusting things like armor or weapon values for balance, while they may be 'fixes' in their own way, are not considered code fixes as described above and require the use of the Pull Request format below.-->


## About The Pull Request

swaps primedecan 6520 for 45 compact, not much of a statistical buff but (1) it's a cooler weapon and (2) 10mms are junkpile loot aswell as being weirdly bugged

swaps prime 'lancer' from a 10mm pistol to 45 custom, reasoning largely highlighted above but to expand, 10mm pistol comes with dysfunctional mags and is a junkloot weapon, this is more of a sidegrade than an upgrade due to mag capacity.

gives gladius to vet by default instead of giving them it in 2/3 of the loadouts (the third is a melee loadout anyway)

gives vet sharpshooter 1911 compact as a secondary weapon, ALL the NCR roles have one aswell as other legion 'sharpshooters' and a box of .44 ammo instead of 3 speedloaders

gives prime forgedmachete instead of having it in loadouts, the 'forgedmachete' was in 1/3 of the Prime loadouts, before someone calls this out as a buff the total difference between 'machete' and 'forgedmachete' is one(1) force, it's a flavour item moreso than anything that separates them from recruits

gives recruit machete by default instead of having it in 1/2 loadouts, reasoning highlighted above

changes recruit loadouts names from "tribal recruit" and "legion recruit" to "tribal" and "recruit" as they're legion regardless

distributes warpaint bowls amongst "tribal" and support legion roles, alongside cent, vex, gives aux ability to craft them. No reason not to do this as the warpaint item is really cool, letting you pick the colours and patterns yourself, it's a flavour item inviting rp from more distinct characters

the only buff in the PR swaps the vet's shield loadout from a 'legion' shield (which primes get) to a bulletproof shield, this item has a custom sprite and has ben in the codebase for a long time, looks cool but only the BoS has ever had access too it, though it is 'bulletproof', all shields currently are, the main 'buff' here is an increase in shield integrity which stops it from breaking aswell as cool points, the loadout also gets 3 armour plates instead of 1 because what the fuck is the point in 1?

by request from cornercube and a couple other people in the discord, swapping the .45 m1911s to .357 revolvers.

takes machete out of explorer's sniper loadout, they spawn with one anyway

## Why It's Good For The Game

Mostly just quality of life stuff, there's nothing in here that really buffs anything, couple sidegrades & it wipes out a bunch of clutter.

![image](https://user-images.githubusercontent.com/89287800/150376314-4a3ef586-5652-4365-a8c7-b99ccff90f9c.png)


## Pre-Merge Checklist
<!-- Don't bother filling these in while creating your Pull Request, just click the checkboxes after the Pull Request is opened and you are redirected to the page. -->
- [X] You tested this on a local server.
- [X] This code did not runtime during testing.
- [X] You documented all of your changes.
<!-- Neither the compiler nor workflow checks are perfect at detecting runtimes and errors. It is important to test your code/feature/fix locally. -->


## Changelog
<!-- This is mostly optional for small Pull Requests, but if you value being credited for your work in-game be sure to fill it out. To opt-out, remove everything below including the start and end :cl: brackets. -->

<!-- If your Pull Request includes a minor single line variable edit, probably do not fill out this changelog. -->
<!-- However, if your pull request includes massive or immediately noticeable changes, briefly describe those changes in some way in this changelog. -->

:cl:
add: Added new things
add: Added more things
del: Removed old things
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
