### PR TITLE
Re-adds BOS Exile and Tribal Outcast loadout

### DIFF
--- a/code/modules/jobs/job_types/wasteland.dm
+++ b/code/modules/jobs/job_types/wasteland.dm
@@ -362,9 +362,11 @@ Raider
 	/datum/outfit/loadout/raider_vault,
 	/datum/outfit/loadout/raider_ncr,
 	/datum/outfit/loadout/raider_legion,
+	/datum/outfit/loadout/raider_bos,
 	/datum/outfit/loadout/quack_doctor,
 	/datum/outfit/loadout/raider_mobster,
-	/datum/outfit/loadout/raider_cannibal
+	/datum/outfit/loadout/raider_cannibal,
+	/datum/outfit/loadout/raider_tribal
 	)
 
 
@@ -556,6 +558,14 @@ Raider
 		/obj/item/ammo_box/magazine/greasegun = 1,
 		/obj/item/book/granter/trait/trekking = 1
 		)
+		
+/datum/outfit/loadout/raider_bos
+	name = "Brotherhood Exile"
+	suit = /obj/item/clothing/suit/armor/f13/exile/bosexile
+	id = /obj/item/card/id/rusted/brokenholodog
+	backpack_contents = list(
+		/obj/item/gun/energy/laser/pistol=1,
+		/obj/item/stock_parts/cell/ammo/ec=2)
 
 /datum/outfit/loadout/raider_sheriff
 	name = "Desperado"

--- a/code/modules/jobs/job_types/wasteland.dm
+++ b/code/modules/jobs/job_types/wasteland.dm
@@ -1423,6 +1423,7 @@ datum/job/wasteland/f13dendoctor
 	..()
 	if(visualsOnly)
 		return
+	ADD_TRAIT(H, TRAIT_TRIBAL, src)
 
 	H.social_faction = FACTION_WASTELAND
 	add_verb(H, /mob/living/proc/create_tribe)


### PR DESCRIPTION
## About The Pull Request

Title. Tribal Outcast was already in the code, and I pulled the old BOS Exile loadout from before it was removed.

Also includes the bugfix in https://github.com/LoneStarF13/LoneStar/pull/246 to consolidate PRs and avoid merge conflicts (adding tribal trait to tribals), which fixes https://github.com/LoneStarF13/LoneStar/issues/200

## Why It's Good For The Game

Now Outlaws can be tribals too, and the BOS Exile loadout was something frequently requested.

## Pre-Merge Checklist
<!-- Don't bother filling these in while creating your Pull Request, just click the checkboxes after the Pull Request is opened and you are redirected to the page. -->
- [ ] You tested this on a local server.
- [ ] This code did not runtime during testing.
- [x] You documented all of your changes.
<!-- Neither the compiler nor workflow checks are perfect at detecting runtimes and errors. It is important to test your code/feature/fix locally. -->
