### PR TITLE
minor anvil balancing

### DIFF
--- a/code/modules/smithing/anvil.dm
+++ b/code/modules/smithing/anvil.dm
@@ -289,7 +289,7 @@
 	name = "basalt brick anvil"
 	desc = "A big block of basalt. Useable as an anvil, better than sandstone. Igneous!"
 	icon_state = "sandvilnoir"
-	anvilquality = -0.5
+	anvilquality = -1
 	itemqualitymax = 8
 
 /obj/structure/anvil/obtainable/basic

--- a/code/modules/smithing/anvil.dm
+++ b/code/modules/smithing/anvil.dm
@@ -275,22 +275,22 @@
 	custom_materials = list(/datum/material/bronze=8000)
 	icon_state = "ratvaranvil"
 	anvilquality = 0
-	itemqualitymax = 4
+	itemqualitymax = 6
 
 /obj/structure/anvil/obtainable/sandstone
 	name = "sandstone brick anvil"
 	desc = "A big block of sandstone. Useable as an anvil."
 	custom_materials = list(/datum/material/sandstone=8000)
 	icon_state = "sandvil"
-	anvilquality = -0.5
-	itemqualitymax = 3
+	anvilquality = -1
+	itemqualitymax = 4
 
 /obj/structure/anvil/obtainable/basalt
 	name = "basalt brick anvil"
 	desc = "A big block of basalt. Useable as an anvil, better than sandstone. Igneous!"
 	icon_state = "sandvilnoir"
 	anvilquality = -0.5
-	itemqualitymax = 4
+	itemqualitymax = 8
 
 /obj/structure/anvil/obtainable/basic
 	name = "anvil"


### PR DESCRIPTION


## About The Pull Request

shifts anvil balance around a bit

## Why It's Good For The Game

sand anvils are cheapest but anything less than 4 quality is basically worthless, so qmax is 4 but aq is now -1

basalt anvils are extremely hard to get so they've been changed to -1 aq but same quality as regular (titanum) anvil

bronze anvil was the same quality as table anvil despite being like 20x more expensive, this brings it inline with the tiering

## Pre-Merge Checklist
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.

## Changelog

:cl:
balance: anvils tweaked
/:cl: