### PR TITLE
Always use vendored NodeJS on Windows and bump dependencies

### DIFF
--- a/dependencies.sh
+++ b/dependencies.sh
@@ -5,20 +5,20 @@
 
 # byond version
 export BYOND_MAJOR=514
-export BYOND_MINOR=1556
+export BYOND_MINOR=1571
 
 #rust_g git tag
 export RUST_G_VERSION=0.4.10
 
 #node version
-export NODE_VERSION=12
-export NODE_VERSION_PRECISE=12.22.4
+export NODE_VERSION=16
+export NODE_VERSION_PRECISE=16.13.2
 
 # SpacemanDMM git tag
 export SPACEMAN_DMM_VERSION=suite-1.7
 
 # Python version for mapmerge and other tools
-export PYTHON_VERSION=3.6.8
+export PYTHON_VERSION=3.7.9
 
 # Auxmos git tag
 export AUXMOS_VERSION=v0.2.3

--- a/tools/bootstrap/node.bat
+++ b/tools/bootstrap/node.bat
@@ -1,11 +1,4 @@
 @echo off
-where node.exe >nul 2>nul
-if %errorlevel% == 0 (
-	echo | set /p printed_str="Using system-wide Node "
-	call node.exe --version
-	call node.exe %*
-	goto exit_with_last_error_level
-)
 call powershell -NoLogo -ExecutionPolicy Bypass -File "%~dp0\node_.ps1" Download-Node
 for /f "tokens=* USEBACKQ" %%s in (`
 	call powershell -NoLogo -ExecutionPolicy Bypass -File "%~dp0\node_.ps1" Get-Path


### PR DESCRIPTION
Removed the code that uses system-wide NodeJS on Windows.
> "A big part of the point of the bootstrap scripts is to provide a reproducible environment"
 _SpaceManiac_

(See; https://github.com/tgstation/tgstation/pull/64461)

Also bumped dependency versions to match current versions.

- NodeJS `12.22.4` -> `16.13.2` (LTS)
- Python `3.6.8` -> `3.7.9`
- BYOND `514.1556` -> `514.1571` (to match the Server Version)