### PR TITLE
Rolls back node to v14.16.1, changes Windows version to the 64-Bit version

### DIFF
--- a/dependencies.sh
+++ b/dependencies.sh
@@ -11,8 +11,8 @@ export BYOND_MINOR=1571
 export RUST_G_VERSION=0.4.10
 
 #node version
-export NODE_VERSION=16
-export NODE_VERSION_PRECISE=16.13.2
+export NODE_VERSION=14
+export NODE_VERSION_PRECISE=14.16.1
 
 # SpacemanDMM git tag
 export SPACEMAN_DMM_VERSION=suite-1.7

--- a/tools/bootstrap/node.bat
+++ b/tools/bootstrap/node.bat
@@ -1,4 +1,5 @@
 @echo off
+set NODE_SKIP_PLATFORM_CHECK=1
 call powershell -NoLogo -ExecutionPolicy Bypass -File "%~dp0\node_.ps1" Download-Node
 for /f "tokens=* USEBACKQ" %%s in (`
 	call powershell -NoLogo -ExecutionPolicy Bypass -File "%~dp0\node_.ps1" Get-Path

--- a/tools/bootstrap/node_.ps1
+++ b/tools/bootstrap/node_.ps1
@@ -30,8 +30,8 @@ if ($Env:TG_BOOTSTRAP_CACHE) {
 	$Cache = $Env:TG_BOOTSTRAP_CACHE
 }
 $NodeVersion = Extract-Variable -Path "$BaseDir\..\..\dependencies.sh" -Key "NODE_VERSION_PRECISE"
-$NodeSource = "https://nodejs.org/download/release/v$NodeVersion/win-x86/node.exe"
-$NodeTargetDir = "$Cache\node-v$NodeVersion"
+$NodeSource = "https://nodejs.org/download/release/v$NodeVersion/win-x64/node.exe"
+$NodeTargetDir = "$Cache\node-v$NodeVersion-x64"
 $NodeTarget = "$NodeTargetDir\node.exe"
 
 ## Just print the path and exit


### PR DESCRIPTION
See https://github.com/tgstation/tgstation/pull/64513
I did a spelling mistake in my commit message, cry about it.