### PR TITLE
Disables Detective

### DIFF
--- a/code/modules/jobs/job_types/oasis.dm
+++ b/code/modules/jobs/job_types/oasis.dm
@@ -800,8 +800,8 @@ Mayor
 /datum/job/oasis/f13detective
 	title = "Detective"
 	flag = F13DETECTIVE
-	total_positions = 1
-	spawn_positions = 1
+	total_positions = 0
+	spawn_positions = 0
 	description = "As a Detective you are a private eye who assists clients to gather evidence, conduct surveillance, find missing people, and verify information. As a private investigator you are not responsible for peacekeeping the valley, but for finding answers. Your life is already over, make the ending mean something."
 	supervisors = "paying clients"
 	selection_color = "#dcba97"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

<!-- NOTE: This format is NOT REQUIRED for things like runtime fixes, code fixes and optimizations. In those instances you should try to give a description of what is being fixed or optimized but are not required to fill out the complete changelog. -->
<!-- Adjusting things like armor or weapon values for balance, while they may be 'fixes' in their own way, are not considered code fixes as described above and require the use of the Pull Request format below.-->


## About The Pull Request

What it says on the tin. Code stays, but slots set to 0.

## Why It's Good For The Game

Detective as a role was implemented on Desert Rose 2 as an imitation of Nick Valentine's role in Fo4, using base ss13 elements from the regular Detective role such as the forensic scanner, crew manifest/security records, etc. The issue is that these tools, while perfectly normal for regular ss13, are heavily meta in the Fallout setting. Security records provide metaknowledge of every single person in Yuma, and without access to security records, the forensic scanner is practically useless.

In addition, the Detective role itself is functionally useless. It is rare that there are any actual crimes in Oasis that need investigating. There is no need for a Detective in a world where all crimes or disputes are solved moments later with a gunfight. When someone commits a crime, it is almost guaranteed that the Deputies (assuming there are any online) will see this and act on it. There is very little for the Detective to do.

Lastly, and (in my opinion) most importantly: there is almost no actual support or accommodation for the Detective within Oasis. The office is puny, being an afterthought in the town's layout. They have very few tools to work with and little in the way of equipment or office space. While one's first reaction to this problem might be to say "Well, give them a bigger office!" this does not solve the other issues with the role, namely that it does not belong to begin with. Rather than adding more support to a role that is effectively dead weight in the town, we should just strip it out.

If someone wants to roleplay as a private investigator, they can just... do that. They don't need a special role for it. We don't need a limited slot-role dedicated to something that people can just RP out with no functional difference.

## Pre-Merge Checklist
<!-- Don't bother filling these in while creating your Pull Request, just click the checkboxes after the Pull Request is opened and you are redirected to the page. -->
- [ ] You tested this on a local server.
- [ ] This code did not runtime during testing.
- [x] You documented all of your changes.
<!-- Neither the compiler nor workflow checks are perfect at detecting runtimes and errors. It is important to test your code/feature/fix locally. -->
