### PR TITLE
It's NERF or Nothing - Tribal Edition

### DIFF
--- a/code/datums/traits/good.dm
+++ b/code/datums/traits/good.dm
@@ -237,13 +237,13 @@
 	if(quirk_holder)
 		quirk_holder.blood_ratio = 1
 
-/datum/quirk/machine_spirits
-	name = "Spirit Blessed"
-	desc = "You respect the teachings of the Machine Spirits."
-	value = 3
+/datum/quirk/tribal_tech
+	name = "Primitive Tech"
+	desc = "You're able to use primitive technology."
+	value = 2
 	mob_trait = TRAIT_MACHINE_SPIRITS
-	gain_text = "<span class='notice'>You have recieved the blessing of the Machine Spirits.</span>"
-	lose_text = "<span class='danger'>You've lost the  blessing of the Machine Spirits.</span>"
+	gain_text = "<span class='notice'>You are now able to use primitive technology.</span>"
+	lose_text = "<span class='danger'>You are no longer able to use primitive technology.</span>"
 	locked = TRUE
 
 /datum/quirk/night_vision

--- a/code/game/objects/items/granters.dm
+++ b/code/game/objects/items/granters.dm
@@ -1047,7 +1047,7 @@
 		desc = "A compendium of knowledge passed down from the elders. It looks to be in poor condition."
 
 /obj/item/book/granter/trait/selection/tribal/attack_self(mob/user)
-	var/list/choices = list("White Legs","Rustwalkers","Dead Horses","Sorrows","Eighties","Wayfarers","Other")
+	var/list/choices = list("White Legs","Rustwalkers","Dead Horses","Sorrows","Eighties","Wayfarers")
 	if(granted_trait == null)
 		var/choice = input("Choose a trait:") in choices
 		switch(choice)
@@ -1057,9 +1057,6 @@
 				granted_trait = TRAIT_BIG_LEAGUES
 				traitname = "White Legs"
 				crafting_recipe_types = list(/datum/crafting_recipe/ninemil, /datum/crafting_recipe/huntingrifle, /datum/crafting_recipe/n99, /datum/crafting_recipe/huntingrifle, /datum/crafting_recipe/m1911, /datum/crafting_recipe/varmintrifle, /datum/crafting_recipe/colt6520)
-			if("Other")
-				granted_trait = TRAIT_LIFEGIVER
-				traitname = "Other"
 			if("Rustwalkers")
 				granted_trait = TRAIT_TECHNOPHREAK
 				traitname = "Rustwalkers"

--- a/code/game/objects/items/granters.dm
+++ b/code/game/objects/items/granters.dm
@@ -1047,7 +1047,7 @@
 		desc = "A compendium of knowledge passed down from the elders. It looks to be in poor condition."
 
 /obj/item/book/granter/trait/selection/tribal/attack_self(mob/user)
-	var/list/choices = list("Hit Them With Sticks","Technophilia","Pugilist","Padded Feet","Veteran Table Climber")
+	var/list/choices = list("Hit Them With Sticks","Technophilia","Pugilist","Padded Feet","Veteran Table Climber","Basic Surgery")
 	if(granted_trait == null)
 		var/choice = input("Choose a trait:") in choices
 		switch(choice)
@@ -1069,7 +1069,10 @@
 				traitname = "treading carefully"
 			if("Veteran Table Climber")
 				granted_trait = TRAIT_FREERUNNING
-				traitname = ".... climbing tables?"
+				traitname = "....climbing tables"
+			if("Basic Surgery")
+				granted_trait = TRAIT_SURGERY_LOW
+				traitname = "basic surgery"
 		return ..()
 
 /obj/item/book/granter/trait/selection/tribal/Initialize()

--- a/code/game/objects/items/granters.dm
+++ b/code/game/objects/items/granters.dm
@@ -1047,31 +1047,29 @@
 		desc = "A compendium of knowledge passed down from the elders. It looks to be in poor condition."
 
 /obj/item/book/granter/trait/selection/tribal/attack_self(mob/user)
-	var/list/choices = list("White Legs","Rustwalkers","Dead Horses","Sorrows","Eighties","Wayfarers")
+	var/list/choices = list("Hit Them With Sticks","Technophilia","Pugilist","Padded Feet","Veteran Table Climber")
 	if(granted_trait == null)
 		var/choice = input("Choose a trait:") in choices
 		switch(choice)
 			if(null)
 				return 0
-			if("White Legs")
+			if("Hit Them With Sticks")
 				granted_trait = TRAIT_BIG_LEAGUES
-				traitname = "White Legs"
+				traitname = "fighting with melee weapons"
 				crafting_recipe_types = list(/datum/crafting_recipe/ninemil, /datum/crafting_recipe/huntingrifle, /datum/crafting_recipe/n99, /datum/crafting_recipe/huntingrifle, /datum/crafting_recipe/m1911, /datum/crafting_recipe/varmintrifle, /datum/crafting_recipe/colt6520)
-			if("Rustwalkers")
+			if("Technophilia")
 				granted_trait = TRAIT_TECHNOPHREAK
-				traitname = "Rustwalkers"
+				traitname = "technology"
 				crafting_recipe_types = list(/datum/crafting_recipe/autoaxe, /datum/crafting_recipe/steelsaw, /datum/crafting_recipe/tools/forged/entrenching_tool, /datum/crafting_recipe/chainsaw)
-			if("Dead Horses")
+			if("Pugilist")
 				granted_trait = TRAIT_IRONFIST
-				traitname = "Dead Horses"
-			if("Sorrows")
+				traitname = "using your fists"
+			if("Padded Feet")
 				granted_trait = TRAIT_LIGHT_STEP
-				traitname = "Sorrows"
-			if("Eighties")
+				traitname = "treading carefully"
+			if("Veteran Table Climber")
 				granted_trait = TRAIT_FREERUNNING
-				traitname = "Eighties"
-			if("Wayfarers")
-				traitname = "Wayfarer"
+				traitname = ".... climbing tables?"
 		return ..()
 
 /obj/item/book/granter/trait/selection/tribal/Initialize()

--- a/code/game/objects/items/granters.dm
+++ b/code/game/objects/items/granters.dm
@@ -1073,6 +1073,9 @@
 			if("Basic Surgery")
 				granted_trait = TRAIT_SURGERY_LOW
 				traitname = "basic surgery"
+			if("Desert Affinity")
+				granted_trait = TRAIT_HARD_YARDS
+				traitname = "trekking"
 		return ..()
 
 /obj/item/book/granter/trait/selection/tribal/Initialize()

--- a/code/game/objects/items/granters.dm
+++ b/code/game/objects/items/granters.dm
@@ -1056,11 +1056,10 @@
 			if("Hit Them With Sticks")
 				granted_trait = TRAIT_BIG_LEAGUES
 				traitname = "fighting with melee weapons"
-				crafting_recipe_types = list(/datum/crafting_recipe/ninemil, /datum/crafting_recipe/huntingrifle, /datum/crafting_recipe/n99, /datum/crafting_recipe/huntingrifle, /datum/crafting_recipe/m1911, /datum/crafting_recipe/varmintrifle, /datum/crafting_recipe/colt6520)
 			if("Technophilia")
 				granted_trait = TRAIT_TECHNOPHREAK
-				traitname = "technology"
-				crafting_recipe_types = list(/datum/crafting_recipe/autoaxe, /datum/crafting_recipe/steelsaw, /datum/crafting_recipe/tools/forged/entrenching_tool, /datum/crafting_recipe/chainsaw)
+				traitname = "technology and crafting"
+				crafting_recipe_types = list(/datum/crafting_recipe/ninemil, /datum/crafting_recipe/huntingrifle, /datum/crafting_recipe/n99, /datum/crafting_recipe/huntingrifle, /datum/crafting_recipe/m1911, /datum/crafting_recipe/varmintrifle, /datum/crafting_recipe/colt6520, /datum/crafting_recipe/autoaxe, /datum/crafting_recipe/steelsaw, /datum/crafting_recipe/tools/forged/entrenching_tool, /datum/crafting_recipe/chainsaw)
 			if("Pugilist")
 				granted_trait = TRAIT_IRONFIST
 				traitname = "using your fists"

--- a/code/modules/jobs/job_types/wasteland.dm
+++ b/code/modules/jobs/job_types/wasteland.dm
@@ -1431,7 +1431,6 @@ datum/job/wasteland/f13dendoctor
 		return
 	ADD_TRAIT(H, TRAIT_TRIBAL, src)
 	ADD_TRAIT(H, TRAIT_GENERIC, src)
-	ADD_TRAIT(H, TRAIT_HARD_YARDS, src)
 	ADD_TRAIT(H, TRAIT_TRAPPER, src)
 	ADD_TRAIT(H, TRAIT_MACHINE_SPIRITS, src)
 	H.grant_language(/datum/language/tribal)
@@ -1492,7 +1491,6 @@ datum/job/wasteland/f13dendoctor
 		/obj/item/stack/medical/gauze/improvised = 1,
 		/obj/item/reagent_containers/pill/patch/healingpowder = 1,
 		/obj/item/book/granter/crafting_recipe/tribal = 1,
-		/obj/item/book/granter/trait/lowsurgery = 1
 	)
 
 //White Legs
@@ -1505,7 +1503,6 @@ datum/job/wasteland/f13dendoctor
 		/obj/item/melee/unarmed/maceglove = 1,
 		/obj/item/gun/ballistic/automatic/pistol/ninemil = 1,
 		/obj/item/reagent_containers/pill/patch/healpoultice = 1,
-		/obj/item/book/granter/trait/iron_fist = 1
 	)
 
 /datum/outfit/loadout/whitelegsranged
@@ -1527,8 +1524,7 @@ datum/job/wasteland/f13dendoctor
 		/obj/item/clothing/under/f13/female/whitelegs = 1,
 		/obj/item/twohanded/fireaxe = 1,
 		/obj/item/gun/ballistic/automatic/pistol/ninemil = 1,
-		/obj/item/book/granter/crafting_recipe/tribal/whitelegs = 1,
-		/obj/item/book/granter/trait/lowsurgery = 1
+		/obj/item/book/granter/crafting_recipe/tribal/whitelegs = 1
 	)
 
 //Dead Horses
@@ -1563,8 +1559,7 @@ datum/job/wasteland/f13dendoctor
 		/obj/item/cultivator=1,
 		/obj/item/reagent_containers/glass/bucket/wood=1,
 		/obj/item/reagent_containers/pill/patch/healingpowder = 2,
-		/obj/item/book/granter/crafting_recipe/tribal/deadhorses = 1,
-		/obj/item/book/granter/trait/lowsurgery = 1
+		/obj/item/book/granter/crafting_recipe/tribal/deadhorses = 1
 	)
 
 //Sorrows
@@ -1579,8 +1574,7 @@ datum/job/wasteland/f13dendoctor
 		/obj/item/reagent_containers/pill/patch/healpoultice = 2,
 		/obj/item/gun/ballistic/bow = 1,
 		/obj/item/storage/belt/tribe_quiver = 1,
-		/obj/item/book/granter/crafting_recipe/tribal/sorrows = 1,
-		/obj/item/book/granter/trait/lowsurgery = 1
+		/obj/item/book/granter/crafting_recipe/tribal/sorrows = 1
 	)
 
 /datum/outfit/loadout/sorrowsshaman
@@ -1596,8 +1590,7 @@ datum/job/wasteland/f13dendoctor
 		/obj/item/warpaint_bowl = 1,
 		/obj/item/toy/crayon/spraycan = 2,
 		/obj/item/book/granter/trait/tagger = 1,
-		/obj/item/book/granter/crafting_recipe/tribal/sorrows = 1,
-		/obj/item/book/granter/trait/lowsurgery = 1
+		/obj/item/book/granter/crafting_recipe/tribal/sorrows = 1
 	)
 
 //Eighties
@@ -1637,8 +1630,7 @@ datum/job/wasteland/f13dendoctor
 		/obj/item/ammo_box/shotgun/slug = 1,
 		/obj/item/reagent_containers/pill/patch/healingpowder = 2,
 		/obj/item/storage/belt/utility/full = 1,
-		/obj/item/book/granter/crafting_recipe/tribal/eighties = 1,
-		/obj/item/book/granter/trait/lowsurgery = 1
+		/obj/item/book/granter/crafting_recipe/tribal/eighties = 1
 	)
 
 //Wayfarers
@@ -1677,7 +1669,6 @@ datum/job/wasteland/f13dendoctor
 		/obj/item/stack/medical/gauze/improvised = 1,
 		/obj/item/reagent_containers/pill/patch/healingpowder = 1,
 		/obj/item/book/granter/crafting_recipe/tribal/wayfarer = 1,
-		/obj/item/book/granter/trait/lowsurgery = 1
 	)
 
 //Rustwalkers
@@ -1716,7 +1707,6 @@ datum/job/wasteland/f13dendoctor
 		/obj/item/circular_saw = 1,
 		/obj/item/reagent_containers/pill/patch/healpoultice = 2,
 		/obj/item/storage/belt/utility/full = 1,
-		/obj/item/book/granter/trait/lowsurgery = 1,
 		/obj/item/book/granter/crafting_recipe/tribal/rustwalkers = 1
 )
 


### PR DESCRIPTION
## About The Pull Request

Previous discussion: https://github.com/LoneStarF13/LoneStar/pull/291

Nerfs the Tribal role:
- Removes hard yards from the role by default, adds it as a selectable trait in their granter book.
- Removes Lifegiver from their trait granter book.
- Removes low surgery and iron fist books from their loadouts.

Turns the Tribal trait granter book options into generic traits, rather than ones named after tribes.

Removes some cringe Wayfarer stuff on TRAIT_MACHINE_SPIRITS and the associated quirk.

## Why It's Good For The Game

**TL;DR** - Tribal is a Wastelander sidegrade but is given up to **seven** traits, many of which are combat related, compared to the **one** given to Wastelanders. Overtuned, nerf now.

Tribal is a Wastelander sidegrade role meant to add flavour and let people form groups. Due to poor balancing, it is absolutely **stacked** with traits for absolutely no reason, whilst having no real OOC restrictions or requirements like the old tribals. Wastelander is given a single trait from their granter book. 
Tribal is given **four** off the bat that remove turf slowdown, give bonuses to butchering, buff healing powder/bitter drink and allow the use of primitive tech. This increases to **five** when they use the trait granter in hand, and can climb to **seven** depending on loadout. A tribal is able to have lifegiver, hard yards and iron fist, 3 powerful combat traits, immediately upon roundstart. Tribal is no longer a melee-focused role, and so that is not a good enough excuse. There are no OOC restrictions on them using firearms.
**Tribal is still pretty much an upgrade to Wastelander with this PR. It just removes most ability to powergame combat when compared to Wastelander.**

As for the changes to the tribal traits, these were upon request from @OneOneThreeEight. The existing traits are confusing to anyone who has not gone code diving and are unnecessarily restricting flavour that other people can't even see.

## Pre-Merge Checklist
<!-- Don't bother filling these in while creating your Pull Request, just click the checkboxes after the Pull Request is opened and you are redirected to the page. -->
- [y] You tested this on a local server.
- [y] This code did not runtime during testing.
- [y] You documented all of your changes.
<!-- Neither the compiler nor workflow checks are perfect at detecting runtimes and errors. It is important to test your code/feature/fix locally. -->


## Changelog
<!-- This is mostly optional for small Pull Requests, but if you value being credited for your work in-game be sure to fill it out. To opt-out, remove everything below including the start and end :cl: brackets. -->

<!-- If your Pull Request includes a minor single line variable edit, probably do not fill out this changelog. -->
<!-- However, if your pull request includes massive or immediately noticeable changes, briefly describe those changes in some way in this changelog. -->

:cl:
tweak: re-flavoured tribal traits and machine_spirits quirk
balance: rebalanced tribal trait selections
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
