### PR TITLE
Thigh highs are back in style.

### DIFF
--- a/code/modules/mob/dead/new_player/sprite_accessories/socks.dm
+++ b/code/modules/mob/dead/new_player/sprite_accessories/socks.dm
@@ -114,11 +114,13 @@
 /datum/sprite_accessory/underwear/socks/stockings_orange
 	name = "Stockings - Orange"
 	icon_state = "stockings_orange"
+*/
 
 /datum/sprite_accessory/underwear/socks/stockings_programmer
 	name = "Stockings - Programmer"
 	icon_state = "stockings_lpink"
 
+/*
 /datum/sprite_accessory/underwear/socks/stockings_purple
 	name = "Stockings - Purple"
 	icon_state = "stockings_purple"
@@ -156,6 +158,8 @@
 	name = "Thigh-high - Freedom"
 	icon_state = "assblastusa_thigh"
 
+*/
+
 /datum/sprite_accessory/underwear/socks/rainbow_thigh
 	name = "Thigh-high - Rainbow"
 	icon_state = "rainbow_thigh"
@@ -172,7 +176,7 @@
 	name = "Thigh-high - Striped"
 	icon_state = "striped_thigh"
 	has_color = TRUE
-*/
+
 
 /datum/sprite_accessory/underwear/socks/thin_thigh
 	name = "Thigh-high - Thin"


### PR DESCRIPTION
## About The Pull Request

This PR gives back striped, red candy cane, green candy cane, rainbow thigh highs and even programmer stockings for the chemistry people in brotherhood of steel. These are mostly for flavor and who doesn't like strips :) 

## Why It's Good For The Game

This is pretty good for the game as it gives more variety if you do chose to put these on instead of having no variety, which doesnt make a little sense, but socks.

## Pre-Merge Checklist
<!-- Don't bother filling these in while creating your Pull Request, just click the checkboxes after the Pull Request is opened and you are redirected to the page. -->
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
<!-- Neither the compiler nor workflow checks are perfect at detecting runtimes and errors. It is important to test your code/feature/fix locally. -->


## Changelog
<!-- This is mostly optional for small Pull Requests, but if you value being credited for your work in-game be sure to fill it out. To opt-out, remove everything below including the start and end :cl: brackets. -->

<!-- If your Pull Request includes a minor single line variable edit, probably do not fill out this changelog. -->
<!-- However, if your pull request includes massive or immediately noticeable changes, briefly describe those changes in some way in this changelog. -->

:cl:
raadds: striped, red candy cane, green candy cane, rainbow thigh highs and even programmer stockings back into the menu
/:cl:
