### PR TITLE
Fewer whitelisted command roles

### DIFF
--- a/code/modules/jobs/jobs.dm
+++ b/code/modules/jobs/jobs.dm
@@ -48,21 +48,15 @@ GLOBAL_LIST_INIT(nonhuman_positions, list(
 	))
 
 GLOBAL_LIST_INIT(command_positions, list(
-	"Head Scribe",
 	"Head Paladin",
 	"Head Knight",
 
 	"NCR Captain",
-	"NCR Lieutenant",
 	"NCR Veteran Ranger",
 
 	"Legion Centurion",
-	"Legion Veteran Decanus",
 
-	"Mayor",
 	"Sheriff",
-
-	"Followers Administrator",
 	))
 
 GLOBAL_LIST_INIT(silicon_whitelist_positions, list(


### PR DESCRIPTION
## About The Pull Request

Unwhitelists the following roles:
- NCR Lieutenant
- Legion Veteran Decanus
- Followers Administrator
- Mayor
- Brotherhood Head Scribe

The roles that remain whitelisted are the following: NCR Captain, NCR Veteran Ranger, Legion Centurion, BoS Head Knight, BoS Head Paladin, and Oasis Sheriff.

## Why It's Good For The Game

Lieutenant and Vet. Decan both unwhitelisted due to popular request. Followers Admin unwhitelisted because it is not as critical of a role as Captain/Centurion. Mayor unwhitelisted for similar reasons, and to encourage more people to play the role.

Head Scribe being unwhitelisted may be a more controversial choice, but I feel it is necessary to promote people playing the role, especially considering that Head Scribes generally have less to do with their authority compared to Head Knights (who have jurisdiction over bunker security) and Head Paladins (which are obviously the most critical command role in the Brotherhood).

## Pre-Merge Checklist
<!-- Don't bother filling these in while creating your Pull Request, just click the checkboxes after the Pull Request is opened and you are redirected to the page. -->
- [ ] You tested this on a local server.
- [ ] This code did not runtime during testing.
- [x] You documented all of your changes.
<!-- Neither the compiler nor workflow checks are perfect at detecting runtimes and errors. It is important to test your code/feature/fix locally. -->
