### PR TITLE
tribal buffs ('new' arrow type, support for faction damage bonus on projectiles)

### DIFF
--- a/code/datums/components/crafting/recipes/recipes_primal.dm
+++ b/code/datums/components/crafting/recipes/recipes_primal.dm
@@ -244,6 +244,15 @@
 	category = CAT_TRIBAL
 	tools = list(TOOL_WORKBENCH)
 
+/datum/crafting_recipe/tribalwar/arrowbronze
+	name = "Bronze Arrow"
+	result = /obj/item/ammo_casing/caseless/arrow/bronze
+	time = 30
+	reqs = list(/obj/item/stack/sheet/bronze = 1,
+				/obj/item/stack/sheet/minera/wood = 1)
+	category = CAT_TRIBAL
+	tools = list(TOOL_WORKBENCH)
+
 /datum/crafting_recipe/tribalwar/arrowpoison
 	name = "Poison Arrow"
 	result = /obj/item/ammo_casing/caseless/arrow/poison
@@ -259,8 +268,8 @@
 	name = "Bone Arrow"
 	result = /obj/item/ammo_casing/caseless/arrow/bone
 	time = 30
-	reqs = list(/obj/item/stack/sheet/bone = 4,
-				/obj/item/stack/sheet/sinew = 1)
+	reqs = list(/obj/item/stack/sheet/bone = 1,
+				/obj/item/stack/sheet/minera/wood = 1)
 	category = CAT_TRIBAL
 	tools = list(TOOL_WORKBENCH)
 	always_available = FALSE

--- a/code/datums/components/crafting/recipes/recipes_primal.dm
+++ b/code/datums/components/crafting/recipes/recipes_primal.dm
@@ -269,7 +269,7 @@
 	result = /obj/item/ammo_casing/caseless/arrow/bone
 	time = 30
 	reqs = list(/obj/item/stack/sheet/bone = 1,
-				/obj/item/stack/sheet/minera/wood = 1)
+				/obj/item/stack/sheet/mineral/wood = 1)
 	category = CAT_TRIBAL
 	tools = list(TOOL_WORKBENCH)
 	always_available = FALSE

--- a/code/datums/components/crafting/recipes/recipes_primal.dm
+++ b/code/datums/components/crafting/recipes/recipes_primal.dm
@@ -249,7 +249,7 @@
 	result = /obj/item/ammo_casing/caseless/arrow/bronze
 	time = 30
 	reqs = list(/obj/item/stack/sheet/bronze = 1,
-				/obj/item/stack/sheet/minera/wood = 1)
+				/obj/item/stack/sheet/mineral/wood = 1)
 	category = CAT_TRIBAL
 	tools = list(TOOL_WORKBENCH)
 

--- a/code/modules/projectiles/ammunition/caseless/arrow.dm
+++ b/code/modules/projectiles/ammunition/caseless/arrow.dm
@@ -50,7 +50,7 @@
 
 /obj/item/ammo_casing/caseless/arrow/bone
 	name = "bone arrow"
-	desc = "An arrow made of bone and sinew. The tip is sharp enough to pierce through a goliath plate."
+	desc = "An arrow made of bone and sinew. The tip is sharp enough to pierce through deathclaw hide."
 	icon_state = "bonearrow"
 	projectile_type = /obj/item/projectile/bullet/reusable/arrow/bone
 

--- a/code/modules/projectiles/projectile.dm
+++ b/code/modules/projectiles/projectile.dm
@@ -362,7 +362,7 @@
 #define FORCE_QDEL 3		//Force deletion.
 
 /obj/item/projectile/proc/process_hit(turf/T, atom/target, qdel_self, hit_something = FALSE)		//probably needs to be reworked entirely when pixel movement is done.
-	if(LAZYLEN(supereffective_faction) && isliving(target)))
+	if(LAZYLEN(supereffective_faction) && isliving(target))
 		var/mob/living/L = target
 		for(var/F in L.faction)
 			if(F in supereffective_faction)

--- a/code/modules/projectiles/projectile.dm
+++ b/code/modules/projectiles/projectile.dm
@@ -362,7 +362,7 @@
 #define FORCE_QDEL 3		//Force deletion.
 
 /obj/item/projectile/proc/process_hit(turf/T, atom/target, qdel_self, hit_something = FALSE)		//probably needs to be reworked entirely when pixel movement is done.
-	if(LAZYLEN(supereffective_faction) && isliving(target))
+	if(isliving(target) && LAZYLEN(supereffective_faction))
 		var/mob/living/L = target
 		for(var/F in L.faction)
 			if(F in supereffective_faction)

--- a/code/modules/projectiles/projectile.dm
+++ b/code/modules/projectiles/projectile.dm
@@ -147,6 +147,9 @@
 	var/impact_effect_type //what type of impact effect to show when hitting something
 	var/log_override = FALSE //is this type spammed enough to not log? (KAs)
 
+	var/supereffective_damage = 0
+	var/list/supereffective_faction //Any mob with a faction that exists in this list will take bonus damage
+
 	var/temporary_unstoppable_movement = FALSE
 
 	///If defined, on hit we create an item of this type then call hitby() on the hit target with this, mainly used for embedding items (bullets) in targets
@@ -238,6 +241,12 @@
 		return BULLET_ACT_HIT
 
 	var/mob/living/L = target
+
+	if(LAZYLEN(supereffective_faction))
+		for(var/F in L.faction)
+			if(F in supereffective_faction)
+				damage += supereffective_damage
+				break
 
 	if(blocked != 100) // not completely blocked
 		if(damage && L.blood_volume && damage_type == BRUTE)

--- a/code/modules/projectiles/projectile.dm
+++ b/code/modules/projectiles/projectile.dm
@@ -242,12 +242,6 @@
 
 	var/mob/living/L = target
 
-	if(LAZYLEN(supereffective_faction))
-		for(var/F in L.faction)
-			if(F in supereffective_faction)
-				damage += supereffective_damage
-				break
-
 	if(blocked != 100) // not completely blocked
 		if(damage && L.blood_volume && damage_type == BRUTE)
 			var/splatter_dir = dir
@@ -368,6 +362,12 @@
 #define FORCE_QDEL 3		//Force deletion.
 
 /obj/item/projectile/proc/process_hit(turf/T, atom/target, qdel_self, hit_something = FALSE)		//probably needs to be reworked entirely when pixel movement is done.
+	if(LAZYLEN(supereffective_faction) && isliving(target)))
+		var/mob/living/L = target
+		for(var/F in L.faction)
+			if(F in supereffective_faction)
+				damage += supereffective_damage
+				break
 	if(QDELETED(src) || !T || !target)		//We're done, nothing's left.
 		if((qdel_self == FORCE_QDEL) || ((qdel_self == QDEL_SELF) && !temporary_unstoppable_movement && !CHECK_BITFIELD(movement_type, UNSTOPPABLE)))
 			qdel(src)

--- a/code/modules/projectiles/projectile/reusable/arrow.dm
+++ b/code/modules/projectiles/projectile/reusable/arrow.dm
@@ -19,7 +19,7 @@
 	damage = 20
 	armour_penetration = 0.10
 	supereffective_damage = 40
-	supereffective_faction = list("hostile", "ant", "supermutant", "deathclaw", "cazador", "raider", "china", "gecko")
+	supereffective_faction = list("hostile", "ant", "supermutant", "deathclaw", "cazador", "raider", "china", "gecko", "wastebot")
 	ammo_type = /obj/item/ammo_casing/caseless/arrow/bone
 
 /obj/item/projectile/bullet/reusable/arrow/bronze //Just some AP shots

--- a/code/modules/projectiles/projectile/reusable/arrow.dm
+++ b/code/modules/projectiles/projectile/reusable/arrow.dm
@@ -19,7 +19,7 @@
 	damage = 20
 	armour_penetration = 0.10
 	supereffective_damage = 40
-	supereffective_faction = list("hostile", "ant", "supermutant", "deathclaw", "cazador", "raider", "china")
+	supereffective_faction = list("hostile", "ant", "supermutant", "deathclaw", "cazador", "raider", "china", "gecko")
 	ammo_type = /obj/item/ammo_casing/caseless/arrow/bone
 
 /obj/item/projectile/bullet/reusable/arrow/bronze //Just some AP shots

--- a/code/modules/projectiles/projectile/reusable/arrow.dm
+++ b/code/modules/projectiles/projectile/reusable/arrow.dm
@@ -13,17 +13,20 @@
 	damage = 0.5
 	ammo_type = /obj/item/ammo_casing/caseless/arrow/ash
 
-/obj/item/projectile/bullet/reusable/arrow/bone //AP for ashwalkers
+/obj/item/projectile/bullet/reusable/arrow/bone //extra mob damage
 	name = "bone arrow"
 	desc = "Arrow made of bone and sinew."
-	damage = 30
-	armour_penetration = 0.35
+	damage = 20
+	armour_penetration = 0.10
+	supereffective_damage = 40
+	supereffective_faction = list("hostile", "ant", "supermutant", "deathclaw", "cazador", "raider", "china")
 	ammo_type = /obj/item/ammo_casing/caseless/arrow/bone
 
 /obj/item/projectile/bullet/reusable/arrow/bronze //Just some AP shots
 	name = "bronze arrow"
 	desc = "Bronze tipped arrow."
-	armour_penetration = 0.2
+	damage = 30
+	armour_penetration = 0.35
 	ammo_type = /obj/item/ammo_casing/caseless/arrow/bronze
 
 //FO13 ARROWS


### PR DESCRIPTION


## About The Pull Request

enables the bronze arrow, which takes the niche the bone arrow used to have

moves the bone arrow from ap to bonus simplemob damage

support for bonus faction damage
## Why It's Good For The Game

bone arrow was dogshit really and not worth using over basic arrow or ap arrow

## Pre-Merge Checklist
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.


## Changelog
<!-- This is mostly optional for small Pull Requests, but if you value being credited for your work in-game be sure to fill it out. To opt-out, remove everything below including the start and end :cl: brackets. -->

<!-- If your Pull Request includes a minor single line variable edit, probably do not fill out this changelog. -->
<!-- However, if your pull request includes massive or immediately noticeable changes, briefly describe those changes in some way in this changelog. -->

:cl:
add: enables the bronze arrow, which takes the niche the bone arrow used to have
balance: moves the bone arrow from ap to bonus simplemob damage
add: support for bonus faction damage on bullet
/:cl:


