### PR TITLE
upgraded varmint rifle (ghetto ratslayer)

### DIFF
--- a/code/datums/components/crafting/guncrafting.dm
+++ b/code/datums/components/crafting/guncrafting.dm
@@ -42,7 +42,7 @@
 
 /obj/item/weaponcrafting/improvised_parts/trigger_assembly
 	name = "firearm trigger assembly"
-	desc = "A modular trigger assembly with a firing pin, this can be used to make a whole bunch of improvised firearss."
+	desc = "A modular trigger assembly with a firing pin, this can be used to make a whole bunch of improvised firearms."
 	icon_state = "trigger_assembly"
 	w_class = WEIGHT_CLASS_SMALL
 

--- a/code/datums/components/crafting/recipes/recipes_weapon_and_ammo.dm
+++ b/code/datums/components/crafting/recipes/recipes_weapon_and_ammo.dm
@@ -384,6 +384,22 @@
 	subcategory = CAT_WEAPON
 	always_available = FALSE
 
+//craftable psuedo-ratslayer
+/datum/crafting_recipe/verminkiller
+	name = "Upgraded Varmint Rifle"
+	result = /obj/item/gun/ballistic/automatic/varmint/verminkiller
+	reqs = list(/obj/item/gun/ballistic/automatic/varmint = 1,
+				/obj/item/gun/ballistic/automatic/delisle = 1,
+				/obj/item/weaponcrafting/improvised_parts/trigger_assembly = 1,
+				/obj/item/advanced_crafting_components/lenses = 1, //scope
+				/obj/item/stack/crafting/goodparts = 3,
+				/obj/item/stack/sheet/mineral/wood = 2,
+				/obj/item/stack/sheet/metal = 15)
+	tools = list(TOOL_WORKBENCH)
+	time = 300 //30 sec
+	category = CAT_WEAPONRY
+	subcategory = CAT_WEAPON
+
 /datum/crafting_recipe/policerifle
 	name = "Police Rifle"
 	result = /obj/item/gun/ballistic/automatic/marksman/policerifle

--- a/code/modules/projectiles/guns/ballistic/automatic.dm
+++ b/code/modules/projectiles/guns/ballistic/automatic.dm
@@ -645,6 +645,21 @@
 	scope_x_offset = 6
 	scope_y_offset = 14
 
+//'Verminkiller'									Keywords: 5.56, 10/20/30 round magazine, Suppressed, Scoped, 25 damage
+//Basically an obtainable ratslayer
+/obj/item/gun/ballistic/automatic/varmint/verminkiller
+	name = "verminkiller rifle"
+	desc = "Legends are told of the \"Ratslayer\", a custom-made souped-up varmint rifle with a sick paintjob. This is a pale imitation, made of chopped-up bits of other guns."
+	icon_state = "ratslayer"
+	item_state = "ratslayer"
+	extra_damage = 25
+	suppressed = 1
+	zoomable = TRUE
+	zoom_amt = 10
+	zoom_out_amt = 13
+	can_scope = FALSE
+	fire_sound = 'sound/weapons/Gunshot_large_silenced.ogg'
+
 //Ratslayer									Keywords: UNIQUE, 5.56, 10/20/30 round magazine, Suppressed, Scoped, Extra damage +3
 /obj/item/gun/ballistic/automatic/varmint/ratslayer
 	name = "Ratslayer"


### PR DESCRIPTION
## About The Pull Request

adds an upgraded varmint rifle, equivalent to the service rifle in damage but with less firedelay

it's suppressed and comes with a scope

## Why It's Good For The Game

oh my fucking god i love the varmint rifle and ratslayer so much i only do varmint rifle runs on nallout few vegas i literally havent touched any other weapon because they're so good

basically a better plinking rifle than the varmint while also usable for other things
non-ballistic weapon that takes a lens, so that's cool

## Pre-Merge Checklist
- [ ] You tested this on a local server.
- [ ] This code did not runtime during testing.
- [ ] You documented all of your changes.


## Changelog


:cl:
add: ghetto ratslayer + recipe
/:cl:

