### PR TITLE
removes ability to make synthtissue

### DIFF
--- a/code/modules/reagents/chemistry/recipes/medicine.dm
+++ b/code/modules/reagents/chemistry/recipes/medicine.dm
@@ -88,8 +88,8 @@ datum/chemical_reaction/rezadone
 	name = "Synthtissue"
 	id = /datum/reagent/synthtissue
 	results = list(/datum/reagent/synthtissue = 5)
-	required_reagents = list(/datum/reagent/medicine/synthflesh = 1)
-	required_catalysts = list(/datum/reagent/consumable/sugar = 0.1)
+	//required_reagents = list(/datum/reagent/medicine/synthflesh = 1)			// LoneStar removal
+	//required_catalysts = list(/datum/reagent/consumable/sugar = 0.1)
 	//FermiChem vars:
 	OptimalTempMin 		= 305		// Lower area of bell curve for determining heat based rate reactions
 	OptimalTempMax 		= 315 		// Upper end for above


### PR DESCRIPTION
## About The Pull Request

removes the ability to make synthtissue through chemistry. chemical itself is still available to admin spawn.
another epic deletion PR

## Why It's Good For The Game

used to extend revival timers past the 20 minute mark, effectively making death/organ decay meaningless if you're with the followers.
hard caps revival timer at 20 minutes.

## Pre-Merge Checklist
<!-- Don't bother filling these in while creating your Pull Request, just click the checkboxes after the Pull Request is opened and you are redirected to the page. -->
- [ ] You tested this on a local server.
- [ ] This code did not runtime during testing.
- [ ] You documented all of your changes.
<!-- Neither the compiler nor workflow checks are perfect at detecting runtimes and errors. It is important to test your code/feature/fix locally. -->


## Changelog
<!-- This is mostly optional for small Pull Requests, but if you value being credited for your work in-game be sure to fill it out. To opt-out, remove everything below including the start and end :cl: brackets. -->

<!-- If your Pull Request includes a minor single line variable edit, probably do not fill out this changelog. -->
<!-- However, if your pull request includes massive or immediately noticeable changes, briefly describe those changes in some way in this changelog. -->

:cl:
del: synthtissue required reagents and catalyst
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
