### PR TITLE
heavily nerfs synthtissue

### DIFF
--- a/code/__DEFINES/reagents.dm
+++ b/code/__DEFINES/reagents.dm
@@ -63,6 +63,10 @@
 
 #define THRESHOLD_UNHUSK 50 // health threshold for synthflesh/rezadone to unhusk someone
 
+#define SYNTHTISSUE_BORROW_CAP 250	//The cap for synthtissue's borrowed health value when used on someone dead or already having borrowed health.
+#define SYNTHTISSUE_DAMAGE_FLIP_CYCLES 45	//After how many cycles the damage will be pure toxdamage as opposed to clonedamage like initially. Gradually changes during its cycles.
+
+
 //reagent bitflags, used for altering how they works
 #define REAGENT_DEAD_PROCESS		(1<<0)	//calls on_mob_dead() if present in a dead body
 #define REAGENT_DONOTSPLIT			(1<<1)	//Do not split the chem at all during processing

--- a/code/game/objects/items/defib.dm
+++ b/code/game/objects/items/defib.dm
@@ -239,7 +239,7 @@
 	item_state = "defibunit"
 	cell = /obj/item/stock_parts/cell/high
 
-/obj/item/defibrillator/primitive/Initialize() 
+/obj/item/defibrillator/primitive/Initialize()
 	. = ..()
 	paddles = make_paddlesprim()
 	update_power()
@@ -441,7 +441,7 @@
 	if((!req_defib && grab_ghost) || (req_defib && defib.grab_ghost))
 		H.notify_ghost_cloning("Your heart is being defibrillated!")
 		H.grab_ghost() // Shove them back in their body.
-	else if(H.can_defib())
+	else if(H.can_revive())
 		H.notify_ghost_cloning("Your heart is being defibrillated. Re-enter your corpse if you want to be revived!", source = src)
 
 	do_help(H, user)

--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -873,16 +873,16 @@
 	update_inv_handcuffed()
 	update_hud_handcuffed()
 
-/mob/living/carbon/proc/can_defib()
+/mob/living/carbon/proc/can_revive(ignore_timelimit = FALSE, maximum_brute_dam = MAX_REVIVE_BRUTE_DAMAGE, maximum_fire_dam = MAX_REVIVE_FIRE_DAMAGE, ignore_heart = FALSE)
 	var/tlimit = DEFIB_TIME_LIMIT * 10
 	var/obj/item/organ/heart = getorgan(/obj/item/organ/heart)
 	if(suiciding || hellbound || HAS_TRAIT(src, TRAIT_HUSK) || AmBloodsucker(src))
 		return
-	if((world.time - timeofdeath) > tlimit)
+	if(!ignore_timelimit && (world.time - timeofdeath) > tlimit)
 		return
-	if((getBruteLoss() >= MAX_REVIVE_BRUTE_DAMAGE) || (getFireLoss() >= MAX_REVIVE_FIRE_DAMAGE))
+	if((getBruteLoss() >= maximum_brute_dam) || (getFireLoss() >= maximum_fire_dam))
 		return
-	if(!heart || (heart.organ_flags & ORGAN_FAILING))
+	if(!ignore_heart && (!heart || (heart.organ_flags & ORGAN_FAILING)))
 		return
 	var/obj/item/organ/brain/BR = getorgan(/obj/item/organ/brain)
 	if(QDELETED(BR) || BR.brain_death || (BR.organ_flags & ORGAN_FAILING) || suiciding)

--- a/code/modules/reagents/chemistry/holder.dm
+++ b/code/modules/reagents/chemistry/holder.dm
@@ -198,6 +198,7 @@
 		var/transfer_amount = T.volume * part
 		if(preserve_data)
 			trans_data = copy_data(T)
+			post_copy_data(T)
 		transferred += "[T] - [transfer_amount]"
 
 		R.add_reagent(T.type, transfer_amount * multiplier, trans_data, chem_temp, T.purity, pH, no_react = TRUE, ignore_pH = TRUE) //we only handle reaction after every reagent has been transfered.
@@ -1086,6 +1087,9 @@
 		trans_data["viruses"] = v.Copy()
 
 	return trans_data
+
+/datum/reagents/proc/post_copy_data(datum/reagent/current_reagent)
+	return current_reagent.post_copy_data()
 
 /datum/reagents/proc/get_reagent(type)
 	var/list/cached_reagents = reagent_list

--- a/code/modules/reagents/chemistry/reagents.dm
+++ b/code/modules/reagents/chemistry/reagents.dm
@@ -182,6 +182,10 @@ GLOBAL_LIST_INIT(name2reagent, build_name2reagent())
 /datum/reagent/proc/on_update(atom/A)
 	return
 
+//Ran by a reagent holder on a specific reagent after copying its data.
+/datum/reagent/proc/post_copy_data()
+	return
+
 // Called when the reagent container is hit by an explosion
 /datum/reagent/proc/on_ex_act(severity)
 	return

--- a/code/modules/reagents/reagent_containers/hypospray.dm
+++ b/code/modules/reagents/reagent_containers/hypospray.dm
@@ -485,7 +485,7 @@
 		return
 
 	var/fp_verb = mode == HYPO_SPRAY ? "spray" : "inject"
-	var/method = mode == HYPO_SPRAY ? TOUCH : INJECT
+	var/method = mode == HYPO_SPRAY ? PATCH  : INJECT
 
 	if(L != user)
 		L.visible_message("<span class='danger'>[user] is trying to [fp_verb] [L] with [src]!</span>", \

--- a/code/modules/research/nanites/nanite_programs/healing.dm
+++ b/code/modules/research/nanites/nanite_programs/healing.dm
@@ -230,7 +230,7 @@
 	var/mob/living/carbon/C = host_mob
 	if(C.get_ghost())
 		return FALSE
-	return C.can_defib()
+	return C.can_revive()
 
 /datum/nanite_program/defib/proc/zap()
 	var/mob/living/carbon/C = host_mob
@@ -247,4 +247,3 @@
 		log_game("[C] has been successfully defibrillated by nanites.")
 	else
 		playsound(C, 'sound/machines/defib_failed.ogg', 50, FALSE)
-

--- a/modular_citadel/code/modules/reagents/chemistry/reagents/healing.dm
+++ b/modular_citadel/code/modules/reagents/chemistry/reagents/healing.dm
@@ -98,8 +98,8 @@
 	description = "Synthetic tissue used for grafting onto damaged organs during surgery, or for treating limb damage. Has a very tight growth window between 305-320, any higher and the temperature will cause the cells to die. Additionally, growth time is considerably long, so chemists are encouraged to leave beakers with said reaction ongoing, while they tend to their other duties."
 	pH = 7.6
 	metabolization_rate = 0.05 //Give them time to graft
-	data = list("grown_volume" = 0, "injected_vol" = 0)
-	var/borrowed_health
+	data = list("grown_volume" = 0, "injected_vol" = 0, "borrowed_health" = 0)
+	var/borrowed_health = 0
 	color = "#FFDADA"
 	value = REAGENT_VALUE_COMMON
 
@@ -107,31 +107,51 @@
 	if(iscarbon(M))
 		var/mob/living/carbon/C = M
 		var/healing_factor = (((data["grown_volume"] / 100) + 1)*reac_volume)
-		if(method in list(PATCH, TOUCH))
-			if (M.stat == DEAD)
-				M.visible_message("The synthetic tissue rapidly grafts into [M]'s wounds, attemping to repair the damage as quickly as possible.")
-				borrowed_health += healing_factor
-				M.adjustBruteLoss(-healing_factor*2)
-				M.adjustFireLoss(-healing_factor*2)
-				M.adjustToxLoss(-healing_factor)
-				M.adjustCloneLoss(-healing_factor)
-				M.updatehealth()
+		if(method == PATCH)	//Needs to actually be applied via patch / hypo / medspray and not just beakersplashed.
+			if (C.stat == DEAD)
+				C.visible_message("The synthetic tissue rapidly grafts into [M]'s wounds, attempting to repair the damage as quickly as possible.")
+				var/preheal_brute = C.getBruteLoss()
+				var/preheal_burn = C.getFireLoss()
+				var/preheal_tox = C.getToxLoss()
+				var/preheal_oxy = C.getOxyLoss()
+				C.adjustBruteLoss(-healing_factor*2)
+				C.adjustFireLoss(-healing_factor*2)
+				C.adjustToxLoss(-healing_factor)
+				C.adjustCloneLoss(-healing_factor)
+				borrowed_health += (preheal_brute - C.getBruteLoss()) + (preheal_burn - C.getFireLoss()) + (preheal_tox - C.getToxLoss()) + ((preheal_oxy - C.getOxyLoss()) / 2)	//Ironically this means that while slimes get damaged by the toxheal, it will reduce borrowed health and longterm effects. Funky!
+				C.updatehealth()
 				if(data["grown_volume"] > 135 && ((C.health + C.oxyloss)>=80))
-					if(M.revive())
-						M.emote("gasp")
+					var/tplus = world.time - M.timeofdeath
+					if(C.can_revive(ignore_timelimit = TRUE, maximum_brute_dam = MAX_REVIVE_BRUTE_DAMAGE / 2, maximum_fire_dam = MAX_REVIVE_FIRE_DAMAGE / 2, ignore_heart = TRUE) && C.revive())
+						C.grab_ghost()
+						C.emote("gasp")
 						borrowed_health *= 2
 						if(borrowed_health < 100)
 							borrowed_health = 100
 						log_combat(M, M, "revived", src)
+						var/list/policies = CONFIG_GET(keyed_list/policy)
+						var/policy = policies[POLICYCONFIG_ON_DEFIB_LATE]	//Always causes memory loss due to the nature of synthtissue
+						if(policy)
+							to_chat(C, policy)
+						C.log_message("revived using synthtissue, [tplus] deciseconds from time of death, considered late revival due to usage of synthtissue.", LOG_GAME)
 			else
+				var/preheal_brute = C.getBruteLoss()
+				var/preheal_burn = C.getFireLoss()
 				M.adjustBruteLoss(-healing_factor)
 				M.adjustFireLoss(-healing_factor)
-				to_chat(M, "<span class='danger'>You feel your flesh merge with the synthetic tissue! It stings like hell!</span>")
+				var/datum/reagent/synthtissue/active_tissue = M.reagents.has_reagent(/datum/reagent/synthtissue)
+				var/imperfect = FALSE 	//Merging with synthtissue that has borrowed health
+				if(active_tissue && active_tissue.borrowed_health)
+					borrowed_health += (preheal_brute - C.getBruteLoss()) + (preheal_burn - C.getFireLoss())
+					imperfect = TRUE
+				to_chat(M, "<span class='danger'>You feel your flesh [imperfect ? "partially and painfully" : ""] merge with the synthetic tissue! It stings like hell[imperfect ? " and is making you feel terribly sick" : ""]!</span>")
 			SEND_SIGNAL(M, COMSIG_ADD_MOOD_EVENT, "painful_medicine", /datum/mood_event/painful_medicine)
+			data["borrowed_health"] += borrowed_health //Preserve health offset
+			borrowed_health = 0	//We are applying this to someone else, so this info will be transferred via data.
 		if(method==INJECT)
 			data["injected_vol"] = reac_volume
 			var/obj/item/organ/heart/H = C.getorganslot(ORGAN_SLOT_HEART)
-			if(data["grown_volume"] > 50 && H.organ_flags & ORGAN_FAILING)
+			if(H && data["grown_volume"] > 50 && H.organ_flags & ORGAN_FAILING)
 				H.applyOrganDamage(-20)
 	..()
 
@@ -145,16 +165,19 @@
 					C.reagents.remove_reagent(type, 15)
 					to_chat(C, "<span class='notice'>You feel something reform inside of you!</span>")
 
-	data["injected_vol"] -= metabolization_rate
+	data["injected_vol"] = max(0, data["injected_vol"] - metabolization_rate * C.metabolism_efficiency)	//No negatives.
 	if(borrowed_health)
-		C.adjustToxLoss(1)
-		C.adjustCloneLoss(1)
-		borrowed_health -= 1
+		var/ratio = (current_cycle > SYNTHTISSUE_DAMAGE_FLIP_CYCLES) ? 0 : (1 - (current_cycle / SYNTHTISSUE_DAMAGE_FLIP_CYCLES))
+		var/payback = 2 * C.metabolism_efficiency	//How much borrowed health we are paying back. Starts as cloneloss, slowly flips over to toxloss.
+		C.adjustToxLoss((1 - ratio) * payback * REAGENTS_EFFECT_MULTIPLIER, forced = TRUE, toxins_type = TOX_OMNI)
+		C.adjustCloneLoss(ratio * payback * REAGENTS_EFFECT_MULTIPLIER)
+		borrowed_health = max(borrowed_health - payback, 0)
 	..()
 
 /datum/reagent/synthtissue/on_merge(passed_data)
 	if(!passed_data)
 		return ..()
+	borrowed_health += max(0, passed_data["borrowed_health"])
 	if(passed_data["grown_volume"] > data["grown_volume"])
 		data["grown_volume"] = passed_data["grown_volume"]
 	if(iscarbon(holder.my_atom))
@@ -166,10 +189,15 @@
 /datum/reagent/synthtissue/on_new(passed_data)
 	if(!passed_data)
 		return ..()
+	borrowed_health = min(passed_data["borrowed_health"] + borrowed_health, SYNTHTISSUE_BORROW_CAP)
 	if(passed_data["grown_volume"] > data["grown_volume"])
 		data["grown_volume"] = passed_data["grown_volume"]
 	update_name()
 	..()
+
+/datum/reagent/synthtissue/post_copy_data()
+	data["borrowed_health"] = 0	//We passed this along to something that needed it, set it back to 0 so we don't do it twice.
+	return ..()
 
 /datum/reagent/synthtissue/proc/update_name() //They are but babes on creation and have to grow unto godhood
 	switch(data["grown_volume"])
@@ -193,9 +221,9 @@
 	C.adjustCloneLoss(borrowed_health*1.25)
 	C.adjustAllOrganLoss(borrowed_health*0.25)
 	M.updatehealth()
-	if(borrowed_health && C.health < -20)
-		M.set_stat(DEAD)
-		M.visible_message("The synthetic tissue degrades off [M]'s wounds as they collapse to the floor.")
+	if(C.stat != DEAD && borrowed_health && C.health < -20)
+		M.visible_message("The synthetic tissue sloughs off [M]'s wounds as they collapse to the floor.")
+		M.death()
 //NEEDS ON_MOB_DEAD()
 
 /datum/reagent/fermi/zeolites

--- a/modular_citadel/code/modules/reagents/chemistry/reagents/healing.dm
+++ b/modular_citadel/code/modules/reagents/chemistry/reagents/healing.dm
@@ -169,7 +169,7 @@
 	if(borrowed_health)
 		var/ratio = (current_cycle > SYNTHTISSUE_DAMAGE_FLIP_CYCLES) ? 0 : (1 - (current_cycle / SYNTHTISSUE_DAMAGE_FLIP_CYCLES))
 		var/payback = 2 * C.metabolism_efficiency	//How much borrowed health we are paying back. Starts as cloneloss, slowly flips over to toxloss.
-		C.adjustToxLoss((1 - ratio) * payback * REAGENTS_EFFECT_MULTIPLIER, forced = TRUE, toxins_type = TOX_OMNI)
+		C.adjustToxLoss((1 - ratio) * payback * REAGENTS_EFFECT_MULTIPLIER, forced = TRUE)
 		C.adjustCloneLoss(ratio * payback * REAGENTS_EFFECT_MULTIPLIER)
 		borrowed_health = max(borrowed_health - payback, 0)
 	..()


### PR DESCRIPTION
port of https://github.com/Citadel-Station-13/Citadel-Station-13/pull/15195

## About The Pull Request

synthtissue now generates 'borrowed health'  when used to revive someome, which slowly accumulates as a mix of toxin/clone damage

tissue will cause memory loss when being revived by it, regardless of time passed since death.

synthtissue must be applied via patch, medical hypospray or medical sprayer to revive, beakersplashing does not work

## Why It's Good For The Game

synthtissue is problematic i guess? outright removal is a bit much but it's surprisingly good in its current state

## Pre-Merge Checklist

- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.



## Changelog


:cl:
balance: synthtissue nerfs (borrowed health, no longer beakersplashable)
/:cl:

