### PR TITLE
makes crushers craftable, buffs them into usability, alllows hostile mobs to be marked

### DIFF
--- a/code/datums/components/crafting/recipes/recipes_forge.dm
+++ b/code/datums/components/crafting/recipes/recipes_forge.dm
@@ -180,7 +180,7 @@
 	tools = list(TOOL_FORGE)
 	category = CAT_WEAPONRY
 	subcategory = CAT_MELEE
-	
+
 /datum/crafting_recipe/melee/forged/throwing
 	name = "Throwing Knife"
 	result = /obj/item/melee/onehanded/knife/throwing
@@ -467,6 +467,33 @@
 	tools = list(TOOL_WORKBENCH, TOOL_WELDER)
 	category = CAT_WEAPONRY
 	subcategory = CAT_MELEE
+
+/datum/crafting_recipe/crusher
+	name = "Kinetic Crusher"
+	result = /obj/item/kinetic_crusher
+	time = 300
+	reqs = list(
+		/obj/item/stack/sheet/metal = 25,
+		/obj/item/stack/crafting/metalparts = 2,
+		/obj/item/stack/crafting/electronicparts = 3,
+		)
+	tools = list(TOOL_WORKBENCH, TOOL_WELDER)
+	category = CAT_WEAPONRY
+	subcategory = CAT_MELEE
+
+/datum/crafting_recipe/glaive
+	name = "Kinetic Glaive"
+	result = /obj/item/kinetic_crusher/glaive
+	time = 100
+	reqs = list(
+		/obj/item/kinetic_crusher/glaive
+		/obj/item/stack/sheet/mineral/titanium = 1,
+		/obj/item/stack/crafting/electronicparts = 5,
+		)
+	tools = list(TOOL_WORKBENCH, TOOL_MULTITOOL)
+	category = CAT_WEAPONRY
+	subcategory = CAT_MELEE
+
 
 /datum/crafting_recipe/tools/forged/fryingpan
 	name = "Frying Pan"

--- a/code/modules/mining/equipment/kinetic_crusher.dm
+++ b/code/modules/mining/equipment/kinetic_crusher.dm
@@ -32,7 +32,7 @@
 /obj/item/kinetic_crusher/cyborg //probably give this a unique sprite later
 	desc = "An integrated version of the standard kinetic crusher with a grinded down axe head to dissuade mis-use against crewmen. Deals damage equal to the standard crusher against creatures, however."
 	force = 10 //wouldn't want to give a borg a 20 brute melee weapon unemagged now would we
-	detonation_damage = 60
+	detonation_damage = 80
 	wielded = 1
 
 /obj/item/kinetic_crusher/Initialize()
@@ -43,7 +43,7 @@
 /obj/item/kinetic_crusher/ComponentInitialize()
 	. = ..()
 	AddComponent(/datum/component/butchering, 60, 110) //technically it's huge and bulky, but this provides an incentive to use it
-	AddComponent(/datum/component/two_handed, force_unwielded=0, force_wielded=20)
+	AddComponent(/datum/component/two_handed, force_unwielded=0, force_wielded=40)
 
 /obj/item/kinetic_crusher/Destroy()
 	QDEL_LIST(trophies)

--- a/code/modules/mining/equipment/kinetic_crusher.dm
+++ b/code/modules/mining/equipment/kinetic_crusher.dm
@@ -25,7 +25,7 @@
 	var/list/trophies = list()
 	var/charged = TRUE
 	var/charge_time = 15
-	var/detonation_damage = 50
+	var/detonation_damage = 60
 	var/backstab_bonus = 30
 	var/wielded = FALSE // track wielded status on item
 

--- a/code/modules/mining/equipment/kinetic_crusher.dm
+++ b/code/modules/mining/equipment/kinetic_crusher.dm
@@ -32,7 +32,7 @@
 /obj/item/kinetic_crusher/cyborg //probably give this a unique sprite later
 	desc = "An integrated version of the standard kinetic crusher with a grinded down axe head to dissuade mis-use against crewmen. Deals damage equal to the standard crusher against creatures, however."
 	force = 10 //wouldn't want to give a borg a 20 brute melee weapon unemagged now would we
-	detonation_damage = 80
+	detonation_damage = 90
 	wielded = 1
 
 /obj/item/kinetic_crusher/Initialize()

--- a/code/modules/mob/living/simple_animal/hostile/hostile.dm
+++ b/code/modules/mob/living/simple_animal/hostile/hostile.dm
@@ -3,6 +3,7 @@
 	stop_automated_movement_when_pulled = 0
 	obj_damage = 40
 	environment_smash = ENVIRONMENT_SMASH_STRUCTURES //Bitflags. Set to ENVIRONMENT_SMASH_STRUCTURES to break closets,tables,racks, etc; ENVIRONMENT_SMASH_WALLS for walls; ENVIRONMENT_SMASH_RWALLS for rwalls
+	mob_size = MOB_SIZE_LARGE
 	var/atom/target
 	var/ranged = FALSE
 	var/rapid = 0 //How many shots per volley.


### PR DESCRIPTION


## About The Pull Request

crushers are now 40 damage when wielded (still 0 unwielded), boneaxe tier with no bonus structure damage
mark detonation damage is up to 60, so 100 damage on mark det (mob only) and 130 on backstab mark det

crushers are now craftable, and can be upgraded into glaives for the price of some titanium

## Why It's Good For The Game

imo crushers should have the niche of extremely high risk/reward vs mobs. this puts them squarely in that category, with very good damage, low range and no defensive options (two hands are required), especially with grognak/buffout


## Pre-Merge Checklist
- [ ] You tested this on a local server.
- [ ] This code did not runtime during testing.
- [ ] You documented all of your changes.


## Changelog

:cl:
add: crafting recipes for the crusher
balance crusher damage 20>40 wielded (boneaxe tier with no ap)
fix: all hostile mobs can now be markdetted with crusher
/:cl:

