### PR TITLE
fixes f13 medicine stacking

### DIFF
--- a/code/modules/fallout/reagents/medicines.dm
+++ b/code/modules/fallout/reagents/medicines.dm
@@ -71,7 +71,7 @@
 /datum/reagent/medicine/stimpakimitation/on_mob_life(mob/living/carbon/M)
 	if(M.getBruteLoss() == 0 && M.getFireLoss() == 0)
 		metabolization_rate = 1000 * REAGENTS_METABOLISM //instant metabolise if it won't help you, prevents prehealing before combat
-	if(!M.reagents.has_reagent(/datum/reagent/medicine/healing_powder)
+	if(!M.reagents.has_reagent(/datum/reagent/medicine/healing_powder))
 		M.adjustBruteLoss(-2.5*REAGENTS_EFFECT_MULTIPLIER)
 		M.adjustFireLoss(-2.5*REAGENTS_EFFECT_MULTIPLIER)
 		M.AdjustKnockdown(-5*REAGENTS_EFFECT_MULTIPLIER, 0)

--- a/code/modules/fallout/reagents/medicines.dm
+++ b/code/modules/fallout/reagents/medicines.dm
@@ -39,7 +39,7 @@
 		M.AdjustUnconscious(-20, 0)
 	if(M.getBruteLoss() == 0 && M.getFireLoss() == 0 && M.getToxLoss() == 0)
 		metabolization_rate = 1000 * REAGENTS_METABOLISM //instant metabolise if it won't help you, prevents prehealing before combat
-	if(!M.reagents.has_reagent(/datum/reagent/medicine/healing_powder)) // We don't want these healing items to stack, so we only apply the healing if these chems aren't found.We only check for the less powerful chems, so the least powerful one always heals.
+	if(!M.reagents.has_reagent(/datum/reagent/medicine/healing_powder) || !M.reagents.has_reagent(/datum/reagent/medicine/stimpakimitation)) // We don't want these healing items to stack, so we only apply the healing if these chems aren't found.We only check for the less powerful chems, so the least powerful one always heals.
 		M.adjustBruteLoss(-4*REAGENTS_EFFECT_MULTIPLIER)
 		M.adjustFireLoss(-4*REAGENTS_EFFECT_MULTIPLIER)
 		M.AdjustStun(-5*REAGENTS_EFFECT_MULTIPLIER, 0)
@@ -71,10 +71,11 @@
 /datum/reagent/medicine/stimpakimitation/on_mob_life(mob/living/carbon/M)
 	if(M.getBruteLoss() == 0 && M.getFireLoss() == 0)
 		metabolization_rate = 1000 * REAGENTS_METABOLISM //instant metabolise if it won't help you, prevents prehealing before combat
-	M.adjustBruteLoss(-2.5*REAGENTS_EFFECT_MULTIPLIER)
-	M.adjustFireLoss(-2.5*REAGENTS_EFFECT_MULTIPLIER)
-	M.AdjustKnockdown(-5*REAGENTS_EFFECT_MULTIPLIER, 0)
-	M.adjustStaminaLoss(-2*REAGENTS_EFFECT_MULTIPLIER)
+	if(!M.reagents.has_reagent(/datum/reagent/medicine/healing_powder)
+		M.adjustBruteLoss(-2.5*REAGENTS_EFFECT_MULTIPLIER)
+		M.adjustFireLoss(-2.5*REAGENTS_EFFECT_MULTIPLIER)
+		M.AdjustKnockdown(-5*REAGENTS_EFFECT_MULTIPLIER, 0)
+		M.adjustStaminaLoss(-2*REAGENTS_EFFECT_MULTIPLIER)
 	..()
 
 /datum/reagent/medicine/super_stimpak
@@ -106,7 +107,7 @@ datum/reagent/medicine/super_stimpak/on_mob_life(mob/living/M)
 		M.AdjustUnconscious(-20, 0)
 	if(M.getBruteLoss() == 0 && M.getFireLoss() == 0 && M.getToxLoss() == 0 && M.getOxyLoss() == 0)
 		metabolization_rate = 1000 * REAGENTS_METABOLISM //instant metabolise if it won't help you, prevents prehealing before combat
-	if(!M.reagents.has_reagent(/datum/reagent/medicine/healing_powder/poultice) && !M.reagents.has_reagent(/datum/reagent/medicine/stimpak) && !M.reagents.has_reagent(/datum/reagent/medicine/healing_powder)) // We don't want these healing items to stack, so we only apply the healing if these chems aren't found. We only check for the less powerful chems, so the least powerful one always heals.
+	if(!M.reagents.has_reagent(/datum/reagent/medicine/healing_powder/poultice) || !M.reagents.has_reagent(/datum/reagent/medicine/stimpak) || !M.reagents.has_reagent(/datum/reagent/medicine/healing_powder) ||  !M.reagents.has_reagent(/datum/reagent/medicine/bitter_drink)) // We don't want these healing items to stack, so we only apply the healing if these chems aren't found. We only check for the less powerful chems, so the least powerful one always heals.
 		M.adjustBruteLoss(-8*REAGENTS_EFFECT_MULTIPLIER)
 		M.adjustFireLoss(-8*REAGENTS_EFFECT_MULTIPLIER)
 		M.AdjustStun(-10*REAGENTS_EFFECT_MULTIPLIER, 0)
@@ -145,7 +146,7 @@ datum/reagent/medicine/super_stimpak/on_mob_life(mob/living/M)
 	if(M.getBruteLoss() == 0 && M.getFireLoss() == 0)
 		metabolization_rate = 3 * REAGENTS_METABOLISM //metabolizes much quicker if not injured
 	var/longpork_heal_rate = (is_longporklover ? longpork_lover_healing : longpork_hurting) * REAGENTS_EFFECT_MULTIPLIER
-	if(!M.reagents.has_reagent(/datum/reagent/medicine/stimpak) && !M.reagents.has_reagent(/datum/reagent/medicine/healing_powder))
+	if(!M.reagents.has_reagent(/datum/reagent/medicine/stimpak) || !M.reagents.has_reagent(/datum/reagent/medicine/healing_powder))
 		M.adjustFireLoss(longpork_heal_rate)
 		M.adjustBruteLoss(longpork_heal_rate)
 		M.adjustToxLoss(is_longporklover ? 0 : 3)
@@ -246,7 +247,7 @@ datum/reagent/medicine/super_stimpak/on_mob_life(mob/living/M)
 	if(M.getBruteLoss() == 0 && M.getFireLoss() == 0)
 		metabolization_rate = 1000 * REAGENTS_METABOLISM //instant metabolise if it won't help you, prevents prehealing before combat
 	var/heal_rate = (is_tribal ? heal_factor_perk : heal_factor) * REAGENTS_EFFECT_MULTIPLIER
-	if(!M.reagents.has_reagent(/datum/reagent/medicine/stimpak) && !M.reagents.has_reagent(/datum/reagent/medicine/healing_powder)&& !M.reagents.has_reagent(/datum/reagent/medicine/super_stimpak))
+	if(!M.reagents.has_reagent(/datum/reagent/medicine/stimpak) || !M.reagents.has_reagent(/datum/reagent/medicine/healing_powder) || !M.reagents.has_reagent(/datum/reagent/medicine/super_stimpak))
 		M.adjustFireLoss(heal_rate)
 		M.adjustBruteLoss(heal_rate)
 		M.adjustToxLoss(heal_rate)


### PR DESCRIPTION
the checks were &&s, so they only ever stopped healing if you were stacking ALL the chemicals



## Pre-Merge Checklist

- [ ] You tested this on a local server.
- [ ] This code did not runtime during testing.
- [ ] You documented all of your changes.


## Changelog


:cl:
fix: stimfluid/powder hp stacking
/:cl:
