### PR TITLE
people now show how long they've been afk/disconnected for on examine, offline indicator no longer appears on mobs that may be revivable but with no ghost in corpse, recusitation message clarification

### DIFF
--- a/code/__DEFINES/mobs.dm
+++ b/code/__DEFINES/mobs.dm
@@ -333,8 +333,12 @@
 
 /// If you examine the same atom twice in this timeframe, we call examine_more() instead of examine()
 #define EXAMINE_MORE_TIME	1 SECONDS
+//simplemob flagf
 
 #define SILENCE_RANGED_MESSAGE (1<<0)
+
+//living flag
+#define HIDE_OFFLINE_INDICATOR (1<<0)
 
 //Respawn timer
 #define RESPAWN_TIMER 3000

--- a/code/game/data_huds.dm
+++ b/code/game/data_huds.dm
@@ -97,11 +97,9 @@
 	var/image/onlineholder = hud_list[ONLINE_HUD]
 	var/icon/I = icon(icon, icon_state, dir)
 	onlineholder.pixel_y = I.Height() - world.icon_size
-	if(client && client.check_rights(R_ADMIN))
-		onlineholder.icon_state = "none"
 	if(!istype(src, /mob/living/carbon/human) && !client)
 		onlineholder.icon_state = "none"
-	else if(istype(src, /mob/living/carbon/human) && !client || !key)
+	else if(istype(src, /mob/living/carbon/human) && !client && !key)
 		onlineholder.icon_state = "offline"
 	else
 		onlineholder.icon_state = "none"

--- a/code/game/data_huds.dm
+++ b/code/game/data_huds.dm
@@ -97,6 +97,8 @@
 	var/image/onlineholder = hud_list[ONLINE_HUD]
 	var/icon/I = icon(icon, icon_state, dir)
 	onlineholder.pixel_y = I.Height() - world.icon_size
+	if(client && client.check_rights(R_ADMIN))
+		onlineholder.icon_state = "none"
 	if(!istype(src, /mob/living/carbon/human) && !client)
 		onlineholder.icon_state = "none"
 	else if(istype(src, /mob/living/carbon/human) && !client || !key)

--- a/code/game/data_huds.dm
+++ b/code/game/data_huds.dm
@@ -97,9 +97,12 @@
 	var/image/onlineholder = hud_list[ONLINE_HUD]
 	var/icon/I = icon(icon, icon_state, dir)
 	onlineholder.pixel_y = I.Height() - world.icon_size
+	if(living_flags & HIDE_OFFLINE_INDICATOR)
+		onlineholder.icon_state = "none"
+		return
 	if(!istype(src, /mob/living/carbon/human) && !client)
 		onlineholder.icon_state = "none"
-	else if(istype(src, /mob/living/carbon/human) && !client && !key)
+	else if(istype(src, /mob/living/carbon/human) && !key)
 		onlineholder.icon_state = "offline"
 	else
 		onlineholder.icon_state = "none"

--- a/code/modules/admin/admin_verbs.dm
+++ b/code/modules/admin/admin_verbs.dm
@@ -367,6 +367,9 @@ GLOBAL_PROTECT(admin_verbs_hideable)
 			message_admins("[key_name_admin(usr)] re-entered corpse")
 		ghost.can_reenter_corpse = 1 //force re-entering even when otherwise not possible
 		ghost.reenter_corpse()
+		if(isliving(mob))
+			var/mob/living/L = mob
+			L.living_flags &= ~HIDE_OFFLINE_INDICATOR
 		SSblackbox.record_feedback("tally", "admin_verb", 1, "Admin Reenter") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
 	else if(isnewplayer(mob))
 		to_chat(src, "<font color='red'>Error: Aghost: Can't admin-ghost whilst in the lobby. Join or Observe first.</font>")
@@ -376,6 +379,9 @@ GLOBAL_PROTECT(admin_verbs_hideable)
 		log_admin("[key_name(usr)] admin ghosted.")
 		message_admins("[key_name_admin(usr)] admin ghosted.")
 		var/mob/body = mob
+		if(isliving(body))
+			var/mob/living/livingbody = body
+			livingbody.living_flags |= HIDE_OFFLINE_INDICATOR
 		body.ghostize(1, voluntary = TRUE)
 		if(body && !body.key)
 			body.key = "@[key]"	//Haaaaaaaack. But the people have spoken. If it breaks; blame adminbus

--- a/code/modules/admin/verbs/SDQL2/SDQL_2.dm
+++ b/code/modules/admin/verbs/SDQL2/SDQL_2.dm
@@ -266,7 +266,7 @@
 	var/selectors_used = FALSE
 	var/list/combined_refs = list()
 	do
-		stop_lag(2)
+		stoplag(2)
 		finished = TRUE
 		for(var/i in running)
 			var/datum/sdql2_query/query = i

--- a/code/modules/admin/verbs/SDQL2/SDQL_2.dm
+++ b/code/modules/admin/verbs/SDQL2/SDQL_2.dm
@@ -266,7 +266,7 @@
 	var/selectors_used = FALSE
 	var/list/combined_refs = list()
 	do
-		CHECK_TICK
+		stop_lag(2)
 		finished = TRUE
 		for(var/i in running)
 			var/datum/sdql2_query/query = i

--- a/code/modules/mob/living/carbon/human/examine.dm
+++ b/code/modules/mob/living/carbon/human/examine.dm
@@ -366,7 +366,7 @@
 				msg += "[t_He] [t_has] a stupid expression on [t_his] face.\n"
 			if(InCritical())
 				msg += "[t_He] [t_is] barely conscious.\n"
-		if(getorgan(/obj/item/organ/brain))
+		if(getorgan(/obj/item/organ/brain) && !(living_flags & HIDE_OFFLINE_INDICATOR))
 			if(!key)
 				msg += "<span class='deadsay'>[t_He] [t_is] totally catatonic. The stresses of the Wasteland must have been too much for [t_him]. Any recovery is unlikely.</span>\n"
 			else if(!client)

--- a/code/modules/mob/living/carbon/human/examine.dm
+++ b/code/modules/mob/living/carbon/human/examine.dm
@@ -140,7 +140,7 @@
 		if(getorgan(/obj/item/organ/brain) && !key && !get_ghost(FALSE, TRUE))
 			. += "<span class='deadsay'>[t_He] [t_is] limp and unresponsive; there are no signs of life and resuscitation is not possible...</span>"
 		else
-			. += "<span class='deadsay'>[t_He] [t_is] limp and unresponsive; there are no signs of life...</span>"
+			. += "<span class='deadsay'>[t_He] [t_is] limp and unresponsive; there are no signs of life, however resuscitation may be possible...</span>"
 
 	if(get_bodypart(BODY_ZONE_HEAD) && !getorgan(/obj/item/organ/brain))
 		. += "<span class='deadsay'>It appears that [t_his] brain is missing...</span>"
@@ -227,7 +227,7 @@
 				msg += "<b>[t_He] [t_has] severe cellular damage!</b>\n"
 			else
 				msg += "<b>[t_He] [t_has] extreme cellular damage!</b>\n"
-			
+
 
 
 	if(fire_stacks > 0)
@@ -371,6 +371,10 @@
 				msg += "<span class='deadsay'>[t_He] [t_is] totally catatonic. The stresses of the Wasteland must have been too much for [t_him]. Any recovery is unlikely.</span>\n"
 			else if(!client)
 				msg += "[t_He] [t_has] a blank, absent-minded stare and appears completely unresponsive to anything. [t_He] may snap out of it soon.\n"
+			else if(client && ((client.inactivity / 10) / 60 > 10)) //10 Minutes
+				msg += "\[Inactive for [round((client.inactivity/10)/60)] minutes\]"
+			else if(disconnect_time)
+				msg += "\[Disconnected/ghosted [round(((world.realtime - disconnect_time)/10)/60)] minutes ago\]"
 
 		if(digitalcamo)
 			msg += "[t_He] [t_is] moving [t_his] body in an unnatural and blatantly inhuman manner.\n"
@@ -446,7 +450,7 @@
 							"<a href='?src=[REF(src)];hud=s;add_comment=1'>\[Add comment\]</a>"), "")
 	else if(isobserver(user) && traitstring)
 		. += "<span class='info'><b>Traits:</b> [traitstring]</span>"
-	
+
 	. += "\n[print_special()]\n"
 
 	SEND_SIGNAL(src, COMSIG_PARENT_EXAMINE, user, .) //This also handles flavor texts now
@@ -468,4 +472,4 @@
 			dat += "[new_text]\n" //dat.Join("\n") doesn't work here, for some reason
 	if(dat.len)
 		dat.Join()
-		return 
+		return

--- a/code/modules/mob/living/living_defines.dm
+++ b/code/modules/mob/living/living_defines.dm
@@ -30,6 +30,7 @@
 
 	var/mobility_flags = MOBILITY_FLAGS_DEFAULT
 
+	var/living_flags = NONE
 	// Combat - Blocking/Parrying system
 	/// Our block_parry_data for unarmed blocks/parries. Currently only used for parrying, as unarmed block isn't implemented yet. YOU MUST RUN [get_block_parry_data(this)] INSTEAD OF DIRECTLY ACCESSING!
 	var/datum/block_parry_data/block_parry_data = /datum/block_parry_data		// defaults to *something* because [combat_flags] dictates whether or not we can unarmed block/parry.
@@ -159,3 +160,5 @@
 	var/sprint_buffer_regen_last = 0		//last world.time this was regen'd for math.
 	var/sprint_stamina_cost = 0.70			//stamina loss per tile while insufficient sprint buffer.
 	//---End
+
+	var/disconnect_time //how long have we been dc'd for

--- a/code/modules/mob/living/login.dm
+++ b/code/modules/mob/living/login.dm
@@ -1,5 +1,6 @@
 /mob/living/Login()
 	..()
+	disconnect_time = null //we are connected
 	//Mind updates
 	sync_mind()
 	mind.show_memory(src, 0)

--- a/code/modules/mob/living/logout.dm
+++ b/code/modules/mob/living/logout.dm
@@ -1,6 +1,7 @@
 /mob/living/Logout()
 	update_z(null)
 	..()
+	disconnect_time = world.realtime
 	if(!key && mind)	//key and mind have become separated.
 		mind.active = 0	//This is to stop say, a mind.transfer_to call on a corpse causing a ghost to re-enter its body.
 	hud_client_check()


### PR DESCRIPTION

## About The Pull Request

people now show how long they've been afk/disconnected for on examine, offline indicator no longer appears on mobs that may be revivable but with no ghost in corpse, recusitation message clarification (revivable/not revivable explicitly written)

## Why It's Good For The Game
clarity good

## Pre-Merge Checklist
untested
- [ ] You tested this on a local server.
- [ ] This code did not runtime during testing.
- [ ] You documented all of your changes.


## Changelog
:cl:
tweak: people now show how long they've been afk/disconnected for on examine, offline indicator no longer appears on mobs that may be revivable but with no ghost in corpse, recusitation message clarification
/:cl:
