### PR TITLE
alternate pathway for making most drugs

### DIFF
--- a/code/modules/reagents/chemistry/recipes/drugs.dm
+++ b/code/modules/reagents/chemistry/recipes/drugs.dm
@@ -93,7 +93,7 @@
 	name = "Turbo"
 	id = /datum/reagent/drug/turbo
 	results = list(/datum/reagent/drug/turbo = 4)
-	required_reagents = list(/datum/reagent/cellulose = 1, /datum/chemical_reaction/cyanide = 1, /datum/reagent/consumable/brocjuice = 1, /datum/reagent/drug/jet = 1) //fairly close to the ingame recipe
+	required_reagents = list(/datum/reagent/cellulose = 1, /datum/reagent/toxin/cyanide = 1, /datum/reagent/consumable/brocjuice = 1, /datum/reagent/drug/jet = 1) //fairly close to the ingame recipe
 	OptimalTempMin 		= 410
 	OptimalTempMax		= 525
 	ExplodeTemp			= 585

--- a/code/modules/reagents/chemistry/recipes/drugs.dm
+++ b/code/modules/reagents/chemistry/recipes/drugs.dm
@@ -111,7 +111,7 @@
 	name = "Psycho"
 	id = /datum/reagent/drug/psycho
 	results = list(/datum/reagent/drug/psycho = 3)
-	required_reagents = list(/datum/reagent/toxin/acid = 1, /datum/reagent/consumable/cavefungusjuice = 1, /datum/reagent/ash = 1)
+	required_reagents = list(/datum/reagent/toxin/acid = 1, /datum/reagent/consumable/cavefungusjuice = 1, /datum/reagent/ash = 1, /datum/reagent/drug/methamphetamine = 1)
 	OptimalTempMin 		= 223
 	OptimalTempMax		= 303
 	ExplodeTemp			= 323
@@ -128,8 +128,8 @@
 /datum/chemical_reaction/buffout
 	name = "Buffout"
 	id = /datum/reagent/drug/buffout
-	results = list(/datum/reagent/drug/buffout = 4)
-	required_reagents = list(/datum/reagent/consumable/sugar = 1, /datum/reagent/phosphorus = 1, /datum/reagent/sulfur = 1, /datum/reagent/consumable/nuka_cola = 1, /datum/reagent/carbondioxide = 1, /datum/reagent/nitrous_oxide = 1, /datum/reagent/consumable/yuccajuice = 2)
+	results = list(/datum/reagent/drug/buffout = 5)
+	required_reagents = list(/datum/reagent/consumable/sugar = 1, /datum/reagent/phosphorus = 1, /datum/reagent/sulfur = 1, /datum/reagent/drug/crank = 1, /datum/reagent/carbondioxide = 1, /datum/reagent/nitrous_oxide = 1, /datum/reagent/consumable/yuccajuice = 2)
 	OptimalTempMin 		= 165
 	OptimalTempMax		= 215
 	ExplodeTemp			= 223

--- a/code/modules/reagents/chemistry/recipes/drugs.dm
+++ b/code/modules/reagents/chemistry/recipes/drugs.dm
@@ -86,7 +86,7 @@
 	CurveSharppH 		= 0.7
 	ThermicConstant		= -6
 	HIonRelease 		= -0.5
-	RateUpLim 			= 5
+	RateUpLim 			= 10
 	FermiChem 			= TRUE
 
 /datum/chemical_reaction/turbo
@@ -104,7 +104,7 @@
 	CurveSharppH 		= 0.7
 	ThermicConstant		= 8
 	HIonRelease 		= 0.5
-	RateUpLim 			= 5
+	RateUpLim 			= 7
 	FermiChem 			= TRUE
 
 /datum/chemical_reaction/psycho
@@ -140,5 +140,5 @@
 	CurveSharppH 		= 0.7
 	ThermicConstant		= 3
 	HIonRelease 		= 0.5
-	RateUpLim 			= 1
+	RateUpLim 			= 3
 	FermiChem 			= TRUE

--- a/code/modules/reagents/chemistry/recipes/drugs.dm
+++ b/code/modules/reagents/chemistry/recipes/drugs.dm
@@ -79,7 +79,7 @@
 	OptimalTempMin 		= 600
 	OptimalTempMax		= 675
 	ExplodeTemp			= 700
-	OptimalpHMin		= 8
+	OptimalpHMin		= 7
 	OptimalpHMax		= 10
 	ReactpHLim			= 2
 	CurveSharpT 		= 5
@@ -112,15 +112,15 @@
 	id = /datum/reagent/drug/psycho
 	results = list(/datum/reagent/drug/psycho = 4)
 	required_reagents = list(/datum/reagent/consumable/ferajuice = 2, /datum/reagent/consumable/cavefungusjuice = 2, /datum/reagent/consumable/nuka_cola = 1)
-	OptimalTempMin 		= 273
+	OptimalTempMin 		= 223
 	OptimalTempMax		= 303
 	ExplodeTemp			= 323
 	OptimalpHMin		= 3
-	OptimalpHMax		= 5
+	OptimalpHMax		= 6
 	ReactpHLim			= 1
 	CurveSharpT 		= 5
 	CurveSharppH 		= 0.7
-	ThermicConstant		= 7
+	ThermicConstant		= 5
 	HIonRelease 		= 0.5
 	RateUpLim 			= 5
 	FermiChem 			= TRUE
@@ -134,11 +134,11 @@
 	OptimalTempMax		= 215
 	ExplodeTemp			= 223
 	OptimalpHMin		= 8
-	OptimalpHMax		= 10
+	OptimalpHMax		= 11
 	ReactpHLim			= 1
 	CurveSharpT 		= 5
 	CurveSharppH 		= 0.7
-	ThermicConstant		= 15
+	ThermicConstant		= 3
 	HIonRelease 		= 0.5
 	RateUpLim 			= 1
 	FermiChem 			= TRUE

--- a/code/modules/reagents/chemistry/recipes/drugs.dm
+++ b/code/modules/reagents/chemistry/recipes/drugs.dm
@@ -128,8 +128,8 @@
 /datum/chemical_reaction/buffout
 	name = "Buffout"
 	id = /datum/reagent/drug/buffout
-	results = list(/datum/reagent/drug/buffout = 5)
-	required_reagents = list(/datum/reagent/consumable/sugar = 1, /datum/reagent/phosphorus = 1, /datum/reagent/sulfur = 1, /datum/reagent/drug/crank = 1, /datum/reagent/carbondioxide = 1, /datum/reagent/nitrous_oxide = 1, /datum/reagent/consumable/yuccajuice = 2)
+	results = list(/datum/reagent/drug/buffout = 10)
+	required_reagents = list(/datum/reagent/consumable/sugar = 1, /datum/reagent/phosphorus = 1, /datum/reagent/sulfur = 1, /datum/reagent/drug/crank = 1, /datum/reagent/carbondioxide = 1, /datum/reagent/nitrous_oxide = 1, /datum/reagent/consumable/yuccajuice = 1)
 	OptimalTempMin 		= 165
 	OptimalTempMax		= 215
 	ExplodeTemp			= 223
@@ -138,7 +138,7 @@
 	ReactpHLim			= 1
 	CurveSharpT 		= 5
 	CurveSharppH 		= 0.7
-	ThermicConstant		= 3
-	HIonRelease 		= 0.5
+	ThermicConstant		= 2
+	HIonRelease 		= 0.25
 	RateUpLim 			= 3
 	FermiChem 			= TRUE

--- a/code/modules/reagents/chemistry/recipes/drugs.dm
+++ b/code/modules/reagents/chemistry/recipes/drugs.dm
@@ -93,7 +93,7 @@
 	name = "Turbo"
 	id = /datum/reagent/drug/turbo
 	results = list(/datum/reagent/drug/turbo = 4)
-	required_reagents = list(/datum/reagent/consumable/ferajuice = 2, /datum/reagent/consumable/agavejuice = 2, /datum/reagent/consumable/ethanol = 1)
+	required_reagents = list(/datum/reagent/cellulose = 1, /datum/chemical_reaction/cyanide = 1, /datum/reagent/consumable/brocjuice = 1, /datum/reagent/drug/jet = 1) //fairly close to the ingame recipe
 	OptimalTempMin 		= 410
 	OptimalTempMax		= 525
 	ExplodeTemp			= 585
@@ -110,8 +110,8 @@
 /datum/chemical_reaction/psycho
 	name = "Psycho"
 	id = /datum/reagent/drug/psycho
-	results = list(/datum/reagent/drug/psycho = 4)
-	required_reagents = list(/datum/reagent/consumable/ferajuice = 2, /datum/reagent/consumable/cavefungusjuice = 2, /datum/reagent/consumable/nuka_cola = 1)
+	results = list(/datum/reagent/drug/psycho = 3)
+	required_reagents = list(/datum/reagent/toxin/acid = 1, /datum/reagent/consumable/cavefungusjuice = 1, /datum/reagent/ash = 1)
 	OptimalTempMin 		= 223
 	OptimalTempMax		= 303
 	ExplodeTemp			= 323
@@ -128,8 +128,8 @@
 /datum/chemical_reaction/buffout
 	name = "Buffout"
 	id = /datum/reagent/drug/buffout
-	results = list(/datum/reagent/drug/buffout = 6)
-	required_reagents = list(/datum/reagent/consumable/yuccajuice = 1, /datum/reagent/consumable/mutjuice = 1, /datum/reagent/consumable/ethanol/buffalo = 1, /datum/reagent/consumable/nuka_cola = 1, /datum/reagent/carbondioxide = 1, /datum/reagent/nitrous_oxide = 1)
+	results = list(/datum/reagent/drug/buffout = 4)
+	required_reagents = list(/datum/reagent/consumable/sugar = 1, /datum/reagent/phosphorus = 1, /datum/reagent/sulfur = 1, /datum/reagent/consumable/nuka_cola = 1, /datum/reagent/carbondioxide = 1, /datum/reagent/nitrous_oxide = 1, /datum/reagent/consumable/yuccajuice = 2)
 	OptimalTempMin 		= 165
 	OptimalTempMax		= 215
 	ExplodeTemp			= 223

--- a/code/modules/reagents/chemistry/recipes/medicine.dm
+++ b/code/modules/reagents/chemistry/recipes/medicine.dm
@@ -338,7 +338,7 @@ datum/chemical_reaction/rezadone
 	required_reagents = list( /datum/reagent/medicine/mannitol = 2, /datum/reagent/water = 2, /datum/reagent/impedrezene = 1)
 
 /datum/chemical_reaction/medsuture
-	required_reagents = list(/datum/reagent/cellulose = 10, /datum/reagent/toxin/formaldehyde = 20, /datum/reagent/medicine/polypyr = 15) //This might be a bit much, reagent cost should be reviewed after implementation.
+	required_reagents = list(/datum/reagent/cellulose = 10, /datum/reagent/toxin/formaldehyde = 20, /datum/reagent/medicine/polypyr = 10) //This might be a bit much, reagent cost should be reviewed after implementation.
 
 /datum/chemical_reaction/medsuture/on_reaction(datum/reagents/holder, created_volume)
 	var/location = get_turf(holder.my_atom)
@@ -346,7 +346,7 @@ datum/chemical_reaction/rezadone
 		new /obj/item/stack/medical/suture/medicated(location)
 
 /datum/chemical_reaction/medmesh
-	required_reagents = list(/datum/reagent/cellulose = 20, /datum/reagent/consumable/aloejuice = 20, /datum/reagent/abraxo_cleaner/sterilizine = 10)
+	required_reagents = list(/datum/reagent/cellulose = 10, /datum/reagent/consumable/aloejuice = 10, /datum/reagent/abraxo_cleaner/sterilizine = 10)
 
 /datum/chemical_reaction/medmesh/on_reaction(datum/reagents/holder, created_volume)
 	var/location = get_turf(holder.my_atom)

--- a/code/modules/reagents/chemistry/recipes/medicine.dm
+++ b/code/modules/reagents/chemistry/recipes/medicine.dm
@@ -410,8 +410,8 @@ datum/chemical_reaction/rezadone
 /datum/chemical_reaction/superstimpak
 	name = "Super Stimpak Fluid"
 	id = /datum/reagent/medicine/super_stimpak
-	results = list(/datum/reagent/medicine/super_stimpak = 3)
-	required_reagents = list(/datum/reagent/blood/synthetics = 1, /datum/reagent/medicine/stimpak = 1, /datum/reagent/consumable/mutjuice = 1)
+	results = list(/datum/reagent/medicine/super_stimpak = 5)
+	required_reagents = list(/datum/reagent/blood/synthetics = 1, /datum/reagent/medicine/stimpak = 1, /datum/reagent/consumable/mutjuice = 1) //1 mutfruit at 50 potency yields 6 mutfruit juice
 	OptimalTempMin 		= 65
 	OptimalTempMax		= 95
 	ExplodeTemp			= 100
@@ -430,7 +430,7 @@ datum/chemical_reaction/rezadone
 	name = "Med-X"
 	id = /datum/reagent/medicine/medx
 	results = list(/datum/reagent/medicine/medx = 4)
-	required_reagents = list(/datum/reagent/drug/aranesp = 1, /datum/reagent/phenol = 1, /datum/reagent/medicine/salglu_solution = 1, /datum/reagent/medicine/stimpakimitation = 1)
+	required_reagents = list(/datum/reagent/drug/aranesp = 1, /datum/reagent/phenol = 1, /datum/reagent/drug/heroin = 1, /datum/reagent/medicine/stimpakimitation = 1)
 	OptimalTempMin 		= 780
 	OptimalTempMax		= 821
 	ExplodeTemp			= 824

--- a/code/modules/reagents/chemistry/recipes/medicine.dm
+++ b/code/modules/reagents/chemistry/recipes/medicine.dm
@@ -420,8 +420,8 @@ datum/chemical_reaction/rezadone
 	ReactpHLim			= 1
 	CurveSharpT 		= 1 //flat tcurve
 	CurveSharppH 		= 0.5
-	ThermicConstant		= 5
-	HIonRelease 		= 0.75
+	ThermicConstant		= 1.5
+	HIonRelease 		= 0.1
 	RateUpLim 			= 50 //this seems quite high but 1. runaway thermals 2. it's very slow since it's 100K
 	FermiChem 			= TRUE
 	FermiExplode 		= FALSE
@@ -431,10 +431,10 @@ datum/chemical_reaction/rezadone
 	id = /datum/reagent/medicine/medx
 	results = list(/datum/reagent/medicine/medx = 4)
 	required_reagents = list(/datum/reagent/consumable/ethanol/pungajuice = 1, /datum/reagent/consumable/daturajuice = 1, /datum/reagent/consumable/coyotejuice = 1, /datum/reagent/medicine/stimpakimitation = 1)
-	OptimalTempMin 		= 800
+	OptimalTempMin 		= 780
 	OptimalTempMax		= 821
 	ExplodeTemp			= 824
-	OptimalpHMin		= 11
+	OptimalpHMin		= 10
 	OptimalpHMax		= 14
 	ReactpHLim			= 1
 	CurveSharpT 		= 10

--- a/code/modules/reagents/chemistry/recipes/medicine.dm
+++ b/code/modules/reagents/chemistry/recipes/medicine.dm
@@ -391,8 +391,8 @@ datum/chemical_reaction/rezadone
 /datum/chemical_reaction/stimpak2
 	name = "Imitation Stimpak Fluid"
 	id = /datum/reagent/medicine/stimpakimitation
-	results = list(/datum/reagent/medicine/stimpakimitation = 3)
-	required_reagents = list(/datum/reagent/consumable/brocjuice = 3, /datum/reagent/consumable/xanderjuice = 3)
+	results = list(/datum/reagent/medicine/stimpakimitation = 2)
+	required_reagents = list(/datum/reagent/consumable/brocjuice = 1, /datum/reagent/consumable/xanderjuice = 1)
 	OptimalTempMin 		= 500 // Lower area of bell curve for determining heat based rate reactions
 	OptimalTempMax		= 650 // Upper end for above
 	ExplodeTemp			= 9999 //Temperature at which reaction explodes

--- a/code/modules/reagents/chemistry/recipes/medicine.dm
+++ b/code/modules/reagents/chemistry/recipes/medicine.dm
@@ -411,7 +411,7 @@ datum/chemical_reaction/rezadone
 	name = "Super Stimpak Fluid"
 	id = /datum/reagent/medicine/super_stimpak
 	results = list(/datum/reagent/medicine/super_stimpak = 3)
-	required_reagents = list(/datum/reagent/blood/synthetics = 1, /datum/reagent/drug/aranesp = 1, /datum/reagent/medicine/stimpak = 1, /datum/reagent/consumable/mutjuice = 1)
+	required_reagents = list(/datum/reagent/blood/synthetics = 1, /datum/reagent/medicine/stimpak = 1, /datum/reagent/consumable/mutjuice = 1)
 	OptimalTempMin 		= 65
 	OptimalTempMax		= 95
 	ExplodeTemp			= 100
@@ -430,7 +430,7 @@ datum/chemical_reaction/rezadone
 	name = "Med-X"
 	id = /datum/reagent/medicine/medx
 	results = list(/datum/reagent/medicine/medx = 4)
-	required_reagents = list(/datum/reagent/consumable/ethanol/pungajuice = 1, /datum/reagent/consumable/daturajuice = 1, /datum/reagent/consumable/coyotejuice = 1, /datum/reagent/medicine/stimpakimitation = 1)
+	required_reagents = list(/datum/reagent/drug/aranesp = 1, /datum/reagent/phenol = 1, /datum/reagent/medicine/salglu_solution = 1, /datum/reagent/medicine/stimpakimitation = 1)
 	OptimalTempMin 		= 780
 	OptimalTempMax		= 821
 	ExplodeTemp			= 824

--- a/code/modules/reagents/chemistry/recipes/others.dm
+++ b/code/modules/reagents/chemistry/recipes/others.dm
@@ -867,7 +867,7 @@
 	CurveSharppH 		= 0.5
 	ThermicConstant		= 4
 	HIonRelease 		= 0.1
-	RateUpLim 			= 5
+	RateUpLim 			= 6
 	FermiChem 			= TRUE
 	FermiExplode 		= FALSE
 


### PR DESCRIPTION


## About The Pull Request

alternate pathway for making most drugs  (jet turbo psycho buffout medx)

instead of grinding a shitload of plants, you need a full chemistry setup, some skill in managing somewhat challenging fermichem reactions and some other various chemical precursors

superstims created via the recipe have significantly better yield due to the added difficulty

## Why It's Good For The Game

having them just be a clone of the workbench recipes was kind of shit because either they'd be better yielding and almost never worth workbenching or too difficult/unrewarding and never worth doing

this attempts to find a middleground in which it's not just mindless farming and crafting or mindless farming and a really difficult recipe for no real gain

## Pre-Merge Checklist

- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.



## Changelog

:cl:
balance: fermichem recipes for drugs/superstims changed. drugs now require less plants (if any) and superstims now yield anywhere from 1.5-2x (potency dependent) as much to compensate for the difficulty
/:cl:

