### PR TITLE
primitive chemistry/grinder improvements

### DIFF
--- a/code/game/objects/items/stacks/sheets/sheet_types.dm
+++ b/code/game/objects/items/stacks/sheets/sheet_types.dm
@@ -293,8 +293,9 @@ GLOBAL_LIST_INIT(wood_recipes, list ( \
 		new /datum/stack_recipe("compost bin", /obj/structure/reagent_dispensers/compostbin, 25, time = 40, one_per_turf = TRUE, on_floor = TRUE), \
 		new /datum/stack_recipe("harvest bin", /obj/machinery/smartfridge/bottlerack/grownbin, 20, time = 40, one_per_turf = TRUE, on_floor = TRUE), \
 		new /datum/stack_recipe("seed bin", /obj/machinery/smartfridge/bottlerack/seedbin, 20, time = 40, one_per_turf = TRUE, on_floor = TRUE), \
-		null, \
 		new /datum/stack_recipe("alchemy rack", /obj/machinery/smartfridge/bottlerack/alchemy_rack, 20, time = 40, one_per_turf = TRUE, on_floor = TRUE),\
+		null, \
+		new /datum/stack_recipe("primitive chemistry table", /obj/machinery/chem_master/primitive, 25, time = 15, one_per_turf = TRUE, on_floor = TRUE),\
 		new /datum/stack_recipe("loom", /obj/structure/loom, 10, time = 15, one_per_turf = TRUE, on_floor = TRUE),\
 		)), \
 	new/datum/stack_recipe_list("cooking", list( \

--- a/code/modules/reagents/chemistry/machinery/chem_master.dm
+++ b/code/modules/reagents/chemistry/machinery/chem_master.dm
@@ -531,11 +531,44 @@
 	flags_1 = NODECONSTRUCT_1
 	can_be_unanchored = TRUE
 
+/obj/machinery/chem_master/primitive/Initialize()
+	..()
+	reagents.maximum_volume = 240
+
+
 /obj/machinery/chem_master/primitive/update_icon_state()
 	if(beaker)
 		icon_state = "alchemy_table"
 	else
 		icon_state = "alchemy_table"
+
+/obj/machinery/chem_master/primitive/attackby(obj/item/I, mob/user, params)
+	if(default_unfasten_wrench(user, I))
+		return
+	if(istype(I, /obj/item/reagent_containers) && !(I.item_flags & ABSTRACT) && I.is_open_container())
+		. = TRUE // no afterattack
+		if(panel_open)
+			to_chat(user, "<span class='warning'>You can't use the [src.name] while its panel is opened!</span>")
+			return
+		var/obj/item/reagent_containers/B = I
+		if(!user.transferItemToLoc(B, src))
+			return
+		replace_beaker(user, B)
+		to_chat(user, "<span class='notice'>You add [B] to [src].</span>")
+		updateUsrDialog()
+		update_icon()
+	else if(!condi && istype(I, /obj/item/storage/pill_bottle))
+		. = TRUE // no afterattack
+		if(panel_open)
+			to_chat(user, "<span class='warning'>You can't use the [src.name] while its panel is opened!</span>")
+			return
+		if(!user.transferItemToLoc(I, src))
+			return
+		replace_pillbottle(user, I)
+		to_chat(user, "<span class='notice'>You add [I] into the dispenser slot.</span>")
+		updateUsrDialog()
+	else
+		return ..()
 
 /obj/machinery/chem_master/primitive/ui_interact(mob/living/user, datum/tgui/ui)
 	ui = SStgui.try_update_ui(user, src, ui)

--- a/code/modules/reagents/chemistry/machinery/chem_master.dm
+++ b/code/modules/reagents/chemistry/machinery/chem_master.dm
@@ -11,7 +11,7 @@
 	resistance_flags = FIRE_PROOF | ACID_PROOF
 	circuit = /obj/item/circuitboard/machine/chem_master
 
-
+	var/basereagents = 100
 	var/obj/item/reagent_containers/beaker = null
 	var/obj/item/storage/pill_bottle/bottle = null
 	var/mode = 1
@@ -26,7 +26,7 @@
 	var/fermianalyze //Give more detail on fermireactions on analysis
 
 /obj/machinery/chem_master/Initialize()
-	create_reagents(100)
+	create_reagents(basereagents)
 
 	//Calculate the span tags and ids fo all the available pill icons
 	var/datum/asset/spritesheet/simple/assets = get_asset_datum(/datum/asset/spritesheet/simple/pills)
@@ -530,10 +530,11 @@
 	idle_power_usage = 0
 	flags_1 = NODECONSTRUCT_1
 	can_be_unanchored = TRUE
+	basereagents = 240
 
 /obj/machinery/chem_master/primitive/Initialize()
-	..()
-	reagents.maximum_volume = 240
+	. = ..()
+
 
 
 /obj/machinery/chem_master/primitive/update_icon_state()

--- a/code/modules/reagents/chemistry/machinery/chem_master.dm
+++ b/code/modules/reagents/chemistry/machinery/chem_master.dm
@@ -547,9 +547,6 @@
 		return
 	if(istype(I, /obj/item/reagent_containers) && !(I.item_flags & ABSTRACT) && I.is_open_container())
 		. = TRUE // no afterattack
-		if(panel_open)
-			to_chat(user, "<span class='warning'>You can't use the [src.name] while its panel is opened!</span>")
-			return
 		var/obj/item/reagent_containers/B = I
 		if(!user.transferItemToLoc(B, src))
 			return
@@ -559,9 +556,6 @@
 		update_icon()
 	else if(!condi && istype(I, /obj/item/storage/pill_bottle))
 		. = TRUE // no afterattack
-		if(panel_open)
-			to_chat(user, "<span class='warning'>You can't use the [src.name] while its panel is opened!</span>")
-			return
 		if(!user.transferItemToLoc(I, src))
 			return
 		replace_pillbottle(user, I)

--- a/code/modules/reagents/chemistry/machinery/chem_master.dm
+++ b/code/modules/reagents/chemistry/machinery/chem_master.dm
@@ -532,11 +532,6 @@
 	can_be_unanchored = TRUE
 	basereagents = 240
 
-/obj/machinery/chem_master/primitive/Initialize()
-	. = ..()
-
-
-
 /obj/machinery/chem_master/primitive/update_icon_state()
 	if(beaker)
 		icon_state = "alchemy_table"

--- a/code/modules/reagents/chemistry/machinery/reagentgrinder.dm
+++ b/code/modules/reagents/chemistry/machinery/reagentgrinder.dm
@@ -15,7 +15,7 @@
 	resistance_flags = ACID_PROOF
 	var/operating = FALSE
 	var/obj/item/reagent_containers/beaker = null
-	var/limit = 10
+	var/limit = 20
 	var/speed = 1
 	var/list/holdingitems
 

--- a/code/modules/reagents/chemistry/recipes/drugs.dm
+++ b/code/modules/reagents/chemistry/recipes/drugs.dm
@@ -12,7 +12,6 @@
 	mix_message = "The mixture violently reacts, leaving behind a few crystalline shards."
 	required_temp = 390
 
-
 /datum/chemical_reaction/krokodil
 	name = "Krokodil"
 	id = /datum/reagent/drug/krokodil

--- a/code/modules/reagents/reagent_containers/glass.dm
+++ b/code/modules/reagents/reagent_containers/glass.dm
@@ -357,7 +357,9 @@
 		/obj/item/reagent_containers/pill/buffout,
 		/obj/item/reagent_containers/pill/patch/jet,
 	)
-
+/obj/item/reagent_containers/glass/mortar/Initialize()
+	. = ..()
+	holdingitems = list()
 /obj/item/reagent_containers/glass/mortar/examine(mob/user)
 	. = ..()
 	. += "<span class='notice'>Alt-click to eject any item put inside.</span>"
@@ -365,12 +367,7 @@
 
 /obj/item/reagent_containers/glass/mortar/AltClick(mob/user)
 	if(LAZYLEN(holdingitems))
-		for(var/i in holdingitems)
-			var/obj/item/O = i
-			O.forceMove(drop_location())
-			holdingitems -= O
-			to_chat(user, "<span class='notice'>You eject the item inside.</span>")
-			return TRUE
+		eject()
 	else
 		mortar_mode = !mortar_mode
 		to_chat(user, "<span class='notice'>You decide to [mortar_mode == MORTAR_JUICE ? "juice the harvest" : "grind the harvest"].</span>")
@@ -378,16 +375,6 @@
 /obj/item/reagent_containers/glass/mortar/attackby(obj/item/I, mob/living/carbon/human/user)
 	if(is_type_in_list(I, blacklistchems))
 		return
-	if(istype(I, /obj/item/storage/bag))
-		var/list/inserted = list()
-		if(SEND_SIGNAL(I, COMSIG_TRY_STORAGE_TAKE_TYPE, /obj/item/reagent_containers/food/snacks/grown, src, 10 - length(holdingitems), null, null, user, inserted))
-			for(var/i in inserted)
-				holdingitems[i] = TRUE
-			if(!I.contents.len)
-				to_chat(user, "<span class='notice'>You empty [I] into [src].</span>")
-			else
-				to_chat(user, "<span class='notice'>You fill [src] to the brim.</span>")
-		return TRUE
 	if(istype(I,/obj/item/pestle))
 		if(LAZYLEN(holdingitems))
 			if(IS_STAMCRIT(user))
@@ -406,6 +393,16 @@
 	if(holdingitems.len >= 10)
 		to_chat(user, "<span class='warning'>The [src] is full!</span>")
 		return
+	if(istype(I, /obj/item/storage/bag))
+		var/list/inserted = list()
+		if(SEND_SIGNAL(I, COMSIG_TRY_STORAGE_TAKE_TYPE, /obj/item/reagent_containers/food/snacks/grown, src, 10 - length(holdingitems), null, null, user, inserted))
+			for(var/i in inserted)
+				holdingitems[i] = TRUE
+			if(!I.contents.len)
+				to_chat(user, "<span class='notice'>You empty [I] into [src].</span>")
+			else
+				to_chat(user, "<span class='notice'>You fill [src] to the brim.</span>")
+		return TRUE
 	if(!I.grind_requirements(src)) //Error messages should be in the objects' definitions
 		return
 	if(I.juice_results || I.grind_results)

--- a/code/modules/reagents/reagent_containers/glass.dm
+++ b/code/modules/reagents/reagent_containers/glass.dm
@@ -394,7 +394,7 @@
 			if(IS_STAMCRIT(user))
 				to_chat(user, "<span class='warning'>You are too tired to work!</span>")
 				return
-			user.adjustStaminaLoss(5)
+			user.adjustStaminaLoss(2 * holdingitems.len) //max 40
 			if(mortar_mode== MORTAR_JUICE)
 				for(var/obj/item/i in holdingitems)
 					if(reagents.total_volume >= reagents.maximum_volume)

--- a/code/modules/reagents/reagent_containers/glass.dm
+++ b/code/modules/reagents/reagent_containers/glass.dm
@@ -381,7 +381,7 @@
 	..()
 	if(istype(I, /obj/item/storage/bag))
 		var/list/inserted = list()
-		if(SEND_SIGNAL(I, COMSIG_TRY_STORAGE_TAKE_TYPE, /obj/item/reagent_containers/food/snacks/grown, src, 20 - length(holdingitems), null, null, user, inserted))
+		if(SEND_SIGNAL(I, COMSIG_TRY_STORAGE_TAKE_TYPE, /obj/item/reagent_containers/food/snacks/grown, src, 10 - length(holdingitems), null, null, user, inserted))
 			for(var/i in inserted)
 				holdingitems[i] = TRUE
 			if(!I.contents.len)

--- a/code/modules/reagents/reagent_containers/glass.dm
+++ b/code/modules/reagents/reagent_containers/glass.dm
@@ -390,6 +390,7 @@
 				to_chat(user, "<span class='notice'>You fill [src] to the brim.</span>")
 		return
 	if(istype(I,/obj/item/pestle))
+		var/obj/item/GI
 		if(LAZYLEN(holdingitems))
 			if(IS_STAMCRIT(user))
 				to_chat(user, "<span class='warning'>You are too tired to work!</span>")
@@ -399,25 +400,25 @@
 				for(var/obj/item/i in holdingitems)
 					if(reagents.total_volume >= reagents.maximum_volume)
 						break
-					var/obj/item/I = i
-					if(I.juice_results)
-						I.on_juice()
-						reagents.add_reagent_list(I.juice_results)
-						to_chat(user, "<span class='notice'>You juice [I] into a fine liquid.</span>")
-						QDEL_NULL(I)
+					GI = i
+					if(GI.juice_results)
+						GI.on_juice()
+						reagents.add_reagent_list(GI.juice_results)
+						to_chat(user, "<span class='notice'>You juice [GI] into a fine liquid.</span>")
+						QDEL_NULL(GI)
 				return
 			else
 				for(var/i in holdingitems)
 					if(reagents.total_volume >= reagents.maximum_volume)
 						break
-					var/obj/item/I = i
-					if(I.grind_results)
-						I.on_grind()
-						reagents.add_reagent_list(I.grind_results)
-						if(I.reagents && (mortar_mode== MORTAR_GRIND)) //food and pills
-							I.reagents.trans_to(src, I.reagents.total_volume, log = "mortar powdering")
-						to_chat(user, "<span class='notice'>You grind [I] into a fine powder.</span>")
-						QDEL_NULL(I)
+					GI = i
+					if(GI.grind_results)
+						GI.on_grind()
+						reagents.add_reagent_list(GI.grind_results)
+						if(GI.reagents && (mortar_mode== MORTAR_GRIND)) //food and pills
+							GI.reagents.trans_to(src, GI.reagents.total_volume, log = "mortar powdering")
+						to_chat(user, "<span class='notice'>You grind [GI] into a fine powder.</span>")
+						QDEL_NULL(GI)
 				return
 		else
 			to_chat(user, "<span class='warning'>There is nothing to grind!</span>")
@@ -426,7 +427,8 @@
 		to_chat(user, "<span class='warning'>There is something inside already!</span>")
 		return
 	if(I.juice_results || I.grind_results)
-		I.forceMove(src)
-		grinded = I
-		return
-	to_chat(user, "<span class='warning'>You can't grind this!</span>")
+		if(user.transferItemToLoc(I, src))
+			to_chat(user, "<span class='notice'>You add [I] to [src].</span>")
+			holdingitems[I] = TRUE
+			return
+	to_chat(user, "<span class='warning'>You can't put this in the mortar!</span>")

--- a/code/modules/reagents/reagent_containers/glass.dm
+++ b/code/modules/reagents/reagent_containers/glass.dm
@@ -423,8 +423,8 @@
 		else
 			to_chat(user, "<span class='warning'>There is nothing to grind!</span>")
 			return
-	if(grinded)
-		to_chat(user, "<span class='warning'>There is something inside already!</span>")
+	if(holdingitems.len >= 10)
+		to_chat(user, "<span class='warning'>There [src] is full!</span>")
 		return
 	if(I.juice_results || I.grind_results)
 		if(user.transferItemToLoc(I, src))


### PR DESCRIPTION
primitive grinder now no longer takes time, can grind 10items at once
all in one grinder now also can hold 2x the amount of grindables
alchemy table is now craftable 

## About The Pull Request

every faction with a chemmaster can now upgrade them to 360u storage basically roundstart. tribal one is immediately stronger in exchange for no upgradabilty

## Why It's Good For The Game

mortar was extremely tedious before


## Pre-Merge Checklist
<!-- Don't bother filling these in while creating your Pull Request, just click the checkboxes after the Pull Request is opened and you are redirected to the page. -->
- [ ] You tested this on a local server.
- [ ] This code did not runtime during testing.
- [ ] You documented all of your changes.
<!-- Neither the compiler nor workflow checks are perfect at detecting runtimes and errors. It is important to test your code/feature/fix locally. -->


## Changelog


:cl:
balance: grinding with mortar and pestle is less tedious now, alchemy table is now craftable and holds more, kitchen grinder now can hold 20 items
/:cl:

