### PR TITLE
sadist loadout tribal quiver>belt

### DIFF
--- a/code/modules/jobs/job_types/wasteland.dm
+++ b/code/modules/jobs/job_types/wasteland.dm
@@ -495,7 +495,7 @@ Raider
 	backpack_contents = list(
 		/obj/item/melee/onehanded/knife/throwing = 5,
 		/obj/item/clothing/mask/gas/explorer/folded=1,
-		/obj/item/storage/belt/tribe_quiver = 1,
+		/obj/item/storage/belt = 1,
 		/obj/item/restraints/legcuffs/beartrap = 2,
 		/obj/item/reverse_bear_trap = 1,
 		/obj/item/melee/unarmed/lacerator = 1,


### PR DESCRIPTION
sadist loadout tribal quiver>belt

tribal quiver literally useless it just holds arrows
belt can hold their knives (COOL and GOOD)
## Changelog

:cl:
balance: sadist loadout tribal quiver>belt
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
