### PR TITLE
power armor changes/emp changes

### DIFF
--- a/_maps/RandomZLevels/VR/yuma_VR.dmm
+++ b/_maps/RandomZLevels/VR/yuma_VR.dmm
@@ -2124,7 +2124,6 @@
 	},
 /area/awaymission/vr/bos/enclavebunker)
 "mZ" = (
-/obj/item/fusion_fuel,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13{
 	icon_state = "redrustyfull"

--- a/_maps/map_files/templates/dungeons/north_bunker_2.dmm
+++ b/_maps/map_files/templates/dungeons/north_bunker_2.dmm
@@ -2264,8 +2264,6 @@
 /turf/open/floor/plating/tunnel,
 /area/f13/bunker)
 "XX" = (
-/obj/item/fusion_fuel,
-/obj/item/fusion_fuel,
 /turf/open/floor/plating/tunnel,
 /area/f13/bunker)
 "XY" = (

--- a/_maps/map_files/templates/dungeons/oasis_bunker_2.dmm
+++ b/_maps/map_files/templates/dungeons/oasis_bunker_2.dmm
@@ -2818,7 +2818,6 @@
 /area/f13/radiation)
 "Yj" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/item/fusion_fuel,
 /turf/open/floor/engine,
 /area/f13/radiation)
 "Yk" = (

--- a/code/__DEFINES/traits.dm
+++ b/code/__DEFINES/traits.dm
@@ -187,6 +187,7 @@
 #define TRAIT_SKITTISH			"skittish"
 #define TRAIT_POOR_AIM			"poor_aim"
 #define TRAIT_INSANE_AIM		"insane_aim" //they don't miss. they never miss. it was all part of their immaculate plan.
+#define SPREAD_CONTROL		"spread_control"
 #define TRAIT_PROSOPAGNOSIA		"prosopagnosia"
 #define TRAIT_DRUNK_HEALING		"drunk_healing"
 #define TRAIT_TAGGER			"tagger"

--- a/code/game/objects/items/devices/radio/intercom.dm
+++ b/code/game/objects/items/devices/radio/intercom.dm
@@ -32,11 +32,9 @@
 	if(!istype(SSticker.mode, /datum/game_mode/clockwork_cult))
 		invisibility = INVISIBILITY_OBSERVER
 		alpha = 125
-		emped = TRUE
 	else
 		invisibility = initial(invisibility)
 		alpha = initial(alpha)
-		emped = FALSE
 	..()
 
 /obj/item/radio/intercom/Initialize(mapload, ndir, building)
@@ -124,7 +122,7 @@
 		last_tick = world.timeofday
 
 		var/area/A = get_area(src)
-		if(!A || emped)
+		if(!A)
 			on = FALSE
 		else
 			on = A.powered(EQUIP) // set "on" to the power status
@@ -150,13 +148,13 @@
 /obj/item/radio/intercom/retro
 	name = "vintage intercom"
 	icon_state = "intercom_retro"
-	
+
 /obj/item/radio/intercom/retro/process()
 	if(((world.timeofday - last_tick) > 30) || ((world.timeofday - last_tick) < 0))
 		last_tick = world.timeofday
 
 		var/area/A = get_area(src)
-		if(!A || emped)
+		if(!A)
 			on = FALSE
 		else
 			on = A.powered(EQUIP) // set "on" to the power status
@@ -169,30 +167,28 @@
 /obj/item/radio/intercom/retro/kebob
 	name = "Oasis intercom"
 	freqlock = TRUE
-	frequency = 1369 
+	frequency = 1369
 	channels = list(RADIO_CHANNEL_TOWN = 1)
 
 /obj/item/radio/intercom/retro/kebob/mayor
 	name = "Mayor's intercom"
 	use_command = TRUE
 	command = TRUE
-	
+
 /obj/item/radio/intercom/retro/foa
 	name = "Clinic intercom"
 	freqlock = TRUE
 	frequency = 1355
 	channels = list(RADIO_CHANNEL_MEDICAL = 1)
-	
+
 /obj/item/radio/intercom/retro/pirate
 	name = "Pirate Radio Broadcaster"
 	desc = "A radio that has been hacked to send and recieve from any frequency."
 	freerange = TRUE
-	canhear_range = 1 
+	canhear_range = 1
 
 /obj/item/radio/intercom/retro/bear
 	name = "NCR intercom"
 	freqlock = TRUE
 	frequency = 1363
 	channels = list(RADIO_CHANNEL_NCR = 1)
-
-

--- a/code/game/objects/items/devices/radio/radio.dm
+++ b/code/game/objects/items/devices/radio/radio.dm
@@ -17,7 +17,6 @@
 	var/on = TRUE
 	var/frequency = FREQ_COMMON
 	var/canhear_range = 3  // The range around the radio in which mobs can hear what it receives.
-	var/emped = 0  // Tracks the number of EMPs currently stacked.
 
 	var/broadcasting = FALSE  // Whether the radio will transmit dialogue it hears nearby.
 	var/listening = TRUE  // Whether the radio is currently receiving.
@@ -399,22 +398,14 @@
 	. = ..()
 	if (. & EMP_PROTECT_SELF)
 		return
-	emped++ //There's been an EMP; better count it
-	var/curremp = emped //Remember which EMP this was
-	if (listening && ismob(loc))	// if the radio is turned on and on someone's person they notice
-		to_chat(loc, "<span class='warning'>\The [src] overloads.</span>")
-	broadcasting = FALSE
-	listening = FALSE
-	for (var/ch_name in channels)
-		channels[ch_name] = 0
-	on = FALSE
-	addtimer(CALLBACK(src, .proc/end_emp_effect, curremp), 2 SECONDS)
-
-/obj/item/radio/proc/end_emp_effect(curremp)
-	if(emped != curremp) //Don't fix it if it's been EMP'd again
-		return FALSE
-	emped = FALSE
-	return TRUE
+	if(prob(severity * 1.5))
+		if(listening && ismob(loc))	// if the radio is turned on and on someone's person they notice
+			to_chat(loc, "<span class='warning'>\The [src] shorts out!</span>")
+		broadcasting = FALSE
+		listening = FALSE
+		for (var/ch_name in channels)
+			channels[ch_name] = 0
+		on = FALSE
 
 ///////////////////////////////
 //////////Borg Radios//////////
@@ -487,9 +478,9 @@
 		qdel(implant)
 	else
 		return ..()
-		
+
 /// Other Radios
-	
+
 /obj/item/radio/tribal
 	name = "primitive radio"
 	icon_state = "radio"
@@ -497,6 +488,3 @@
 	desc = "a homemade radio transceiver made out of transistors and wire."
 	canhear_range = 2
 	w_class = WEIGHT_CLASS_NORMAL
-		
-
-	

--- a/code/modules/clothing/head/f13head.dm
+++ b/code/modules/clothing/head/f13head.dm
@@ -261,25 +261,6 @@
 		return ..()
 	return
 
-/obj/item/clothing/head/helmet/f13/power_armor/emp_act(mob/living/carbon/human/owner, severity)
-	. = ..()
-	if(. & EMP_PROTECT_SELF)
-		return
-	if(!powered)
-		return
-	var/curremp = emped
-	if(ismob(loc))
-		to_chat(L, "<span class='warning'>Warning: electromagnetic surge detected in helmet. Rerouting power to emergency systems.</span>")
-		addtimer(CALLBACK(src, .proc/end_emp_effect), 5 SECONDS)
-
-/obj/item/clothing/head/helmet/f13/power_armor/proc/end_emp_effect()
-	if(ismob(loc))
-		var/mob/living/L = loc
-		to_chat(L, "<span class='warning'>Helmet power reroute successful. All systems operational.</span>")
-		if(istype(L))
-			L.update_equipment_speed_mods()
-	return TRUE
-
 /obj/item/clothing/head/helmet/f13/power_armor/t45b
 	name = "salvaged T-45b helmet"
 	desc = "It's a salvaged T-45b power armor helmet."

--- a/code/modules/clothing/head/f13head.dm
+++ b/code/modules/clothing/head/f13head.dm
@@ -235,72 +235,8 @@
 	light_system = MOVABLE_LIGHT_DIRECTIONAL
 	light_range = 5
 	light_on = FALSE
-//	darkness_view = 128
-//	lighting_alpha = LIGHTING_PLANE_ALPHA_NV_TRAIT
-	var/emped = 0
 	var/requires_training = TRUE
-	var/armor_block_chance = 0
-//	protected_zones = list(BODY_ZONE_HEAD)
-//	var/deflection_chance = 0
-//	var/armor_block_threshold = 0.2 //projectiles below this will deflect
-//	var/melee_block_threshold = 30
-//	var/dmg_block_threshold = 42
-	var/powerLevel = 7000
-	var/powerMode = 3
 	var/powered = TRUE
-
-/obj/item/clothing/head/helmet/f13/power_armor/attackby(obj/item/I, mob/user, params)
-	. = ..()
-	if(istype(I,/obj/item/fusion_fuel)&& powered)
-		var/obj/item/fusion_fuel/fuel = I
-		if(src.powerLevel>=50000)
-			to_chat(user, "The fusion core is full.")
-			return
-		if(fuel.fuel >= 5000)
-			src.powerLevel += 5000
-			fuel.fuel -= 5000
-			to_chat(user, "You charge the fusion core to [src.powerLevel] units of fuel. [fuel.fuel]/20000 left in the fuel cell.")
-			return
-		to_chat(user, "The fuel cell is empty.")
-
-/obj/item/clothing/head/helmet/f13/power_armor/proc/processPower()
-	if(powerLevel>0)//drain charge
-		powerLevel -= 1
-	if(powerLevel > 20000)//switch to 3 power mode
-		if(powerMode <= 2)
-			powerUp()
-		return
-	if(powerLevel > 10000)//switch to 2 power
-		if(powerMode <= 1)
-			powerUp()
-		if(powerMode > 2)
-			powerDown()
-		return
-	if(powerLevel > 5000)//switch to 1 power
-		if(powerMode <= 0)
-			powerUp()
-		if(powerMode > 1)
-			powerDown()
-		return
-	if(powerLevel >= 1)//switch to 0 power
-		if(powerMode >= 0)
-			powerDown()
-
-/obj/item/clothing/head/helmet/f13/power_armor/proc/powerUp()
-	powerMode += 1
-	slowdown -= 0.2
-	var/mob/living/L = loc
-	if(istype(L))
-		L.update_equipment_speed_mods()
-	armor = armor.modifyRating(linemelee = 75, linebullet = 75, linelaser = 75)
-
-/obj/item/clothing/head/helmet/f13/power_armor/proc/powerDown()
-	powerMode -= 1
-	slowdown += 0.2
-	var/mob/living/L = loc
-	if(istype(L))
-		L.update_equipment_speed_mods()
-	armor = armor.modifyRating(linemelee = -75, linebullet = -75, linelaser = -75)
 
 /obj/item/clothing/head/helmet/f13/power_armor/ComponentInitialize()
 	. = ..()
@@ -329,50 +265,27 @@
 	. = ..()
 	if(. & EMP_PROTECT_SELF)
 		return
-	emped++
+	if(!powered)
+		return
 	var/curremp = emped
 	if(ismob(loc))
-		to_chat(loc, "<span class='warning'>Warning: electromagnetic surge detected in helmet. Rerouting power to emergency systems.</span>")
-		armor = armor.modifyRating(melee = -100, bullet = -100, laser = -100)
-		addtimer(CALLBACK(src, .proc/end_emp_effect, curremp), 5 SECONDS)
+		to_chat(L, "<span class='warning'>Warning: electromagnetic surge detected in helmet. Rerouting power to emergency systems.</span>")
+		addtimer(CALLBACK(src, .proc/end_emp_effect), 5 SECONDS)
 
-/obj/item/clothing/head/helmet/f13/power_armor/proc/end_emp_effect(curremp)
-	if(emped != curremp) //Don't fix it if it's been EMP'd again
-		return FALSE
+/obj/item/clothing/head/helmet/f13/power_armor/proc/end_emp_effect()
 	if(ismob(loc))
 		var/mob/living/L = loc
-		emped = FALSE
-		to_chat(loc, "<span class='warning'>Helmet power reroute successful. All systems operational.</span>")
-		armor = armor.modifyRating(melee = 100, bullet = 100,laser = 100)
+		to_chat(L, "<span class='warning'>Helmet power reroute successful. All systems operational.</span>")
 		if(istype(L))
 			L.update_equipment_speed_mods()
 	return TRUE
-/*
-/obj/item/clothing/head/helmet/f13/power_armor/run_block(mob/living/owner, atom/object, damage, attack_text, attack_type, armour_penetration, mob/attacker, def_zone, final_block_chance, list/block_return)
-	. = ..()
-	if(damage >= src.dmg_block_threshold && check_armor_penetration(object) >= 0)
-		return
-	if(check_armor_penetration(object) <= src.armor_block_threshold && (attack_type == ATTACK_TYPE_PROJECTILE) && (def_zone in protected_zones))
-		if(prob(armor_block_chance))
-			var/ratio = rand(0,100)
-			if(ratio <= deflection_chance)
-				block_return[BLOCK_RETURN_REDIRECT_METHOD] = REDIRECT_METHOD_DEFLECT
-				return BLOCK_SHOULD_REDIRECT | BLOCK_REDIRECTED | BLOCK_SUCCESS | BLOCK_PHYSICAL_INTERNAL
-			if(ismob(loc))
-				to_chat(loc, "<span class='warning'>Your power armor absorbs the projectile's impact!</span>")
-			block_return[BLOCK_RETURN_SET_DAMAGE_TO] = 0
-			return BLOCK_SUCCESS | BLOCK_PHYSICAL_INTERNAL
-	return
-*/
+
 /obj/item/clothing/head/helmet/f13/power_armor/t45b
 	name = "salvaged T-45b helmet"
 	desc = "It's a salvaged T-45b power armor helmet."
 	icon_state = "t45bhelmet"
 	item_state = "t45bhelmet"
-	armor = list("melee" = 75, "bullet" = 75, "laser" = 75, "energy" = 20, "bomb" = 50, "bio" = 60, "rad" = 50, "fire" = 80, "acid" = 0, "wound" = 40)
-//	darkness_view = 0
-//	armor_block_chance = 25
-//	deflection_chance = 10 //10% chance to block damage from blockable bullets and redirect the bullet at a random angle. Not nearly as effective as true power armor
+	armor = list("melee" = 70, "bullet" = 70, "laser" = 70, "energy" = 20, "bomb" = 50, "bio" = 60, "rad" = 50, "fire" = 80, "acid" = 0, "wound" = 40)
 	requires_training = FALSE
 	powered = FALSE
 
@@ -381,19 +294,14 @@
 	desc = "It's an NCR salvaged T-45b power armor helmet, better repaired than regular salvaged PA, and decorated with the NCR flag and other markings for an NCR Heavy Trooper."
 	icon_state = "t45bhelmet_ncr"
 	item_state = "t45bhelmet_ncr"
-	armor = list("melee" = 75, "bullet" = 75, "laser" = 75, "energy" = 24, "bomb" = 50, "bio" = 60, "rad" = 50, "fire" = 80, "acid" = 0, "wound" = 40)
-//	darkness_view = 0
-//	armor_block_chance = 40
-//	deflection_chance = 10 //10% chance to block damage from blockable bullets and redirect the bullet at a random angle. Not nearly as effective as true power armor
+	armor = list("melee" = 70, "bullet" = 70, "laser" = 70, "energy" = 24, "bomb" = 50, "bio" = 60, "rad" = 50, "fire" = 80, "acid" = 0, "wound" = 40)
 	requires_training = FALSE
 	powered = FALSE
 
 /obj/item/clothing/head/helmet/f13/power_armor/t45b/restored
 	name = "restored T-45b helmet"
 	desc = "It's a restored T-45b power armor helmet."
-	armor = list("melee" = 75, "bullet" = 75, "laser" = 75, "energy" = 22, "bomb" = 55, "bio" = 65, "rad" = 55, "fire" = 85, "acid" = 0, "wound" = 40)
-//	armor_block_chance = 60
-//	deflection_chance = 10 //20% chance to block damage from blockable bullets and redirect the bullet at a random angle
+	armor = list("melee" = 70, "bullet" = 70, "laser" = 70, "energy" = 22, "bomb" = 55, "bio" = 65, "rad" = 55, "fire" = 85, "acid" = 0, "wound" = 40)
 	requires_training = TRUE
 	powered = TRUE
 
@@ -404,39 +312,9 @@
 	item_state = "raiderpa_helm"
 	armor = list("melee" = 65, "bullet" = 55, "laser" = 55, "energy" = 20, "bomb" = 50, "bio" = 60, "rad" = 50, "fire" = 80, "acid" = 0, "wound" = 40)
 	requires_training = FALSE
-//	armor_block_chance = 20
-//	deflection_chance = 10
 	powered = FALSE
 	slowdown = 0.05
 
-
-/obj/item/clothing/head/helmet/f13/power_armor/hotrod
-	name = "hotrod T-45b power helmet"
-	desc = "This power armor helmet is so decrepit and battle-worn that it have lost most of its capability to protect the wearer from harm."
-	icon_state = "t45hotrod_helm"
-	item_state = "t45hotrod_helm"
-	armor = list("melee" = 55, "bullet" = 55, "laser" = 55, "energy" = 20, "bomb" = 50, "bio" = 60, "rad" = 50, "fire" = 80, "acid" = 0, "wound" = 40)
-	requires_training = FALSE
-//	armor_block_chance = 20
-	powered = FALSE
-//	deflection_chance = 10 //5% chance to block damage from blockable bullets and redirect the bullet at a random angle. Stripped down version of an already stripped down version
-	slowdown = 0.05
-
-/obj/item/clothing/head/helmet/f13/power_armor/vaulttec
-	name = "Vault-Tec power helmet"
-	desc = "(VIII) A refined suit of power armour, purpose-built by the residents of Vault-115 in order to better keep the peace in their new settlement."
-	icon_state = "vaultpahelm"
-	item_state = "vaultpahelm"
-	armor = list("tier" = 8, "energy" = 50, "bomb" = 48, "bio" = 60, "rad" = 50, "fire" = 80, "acid" = 0, "wound" = 40)
-//	armor_block_chance = 40
-//	deflection_chance = 10 //10% chance to block damage from blockable bullets and redirect the bullet at a random angle. Not a heavy combat model
-
-/obj/item/clothing/head/helmet/f13/power_armor/vaulttecta
-	name = "Vault-Tec power helmet"
-	desc = "A refined suit of power armour, purpose-built by the residents of Vault-115 in order to better keep the peace in their new settlement."
-	icon_state = "vaulttahelm"
-	item_state = "vaulttahelm"
-	slowdown = 0.1
 
 /obj/item/clothing/head/helmet/f13/power_armor/t45d
 	name = "T-45d power helmet"
@@ -444,7 +322,7 @@
 	icon_state = "t45dhelmet0"
 	item_state = "t45dhelmet0"
 	actions_types = list(/datum/action/item_action/toggle_helmet_light)
-	armor = list("melee" = 75, "bullet" = 75, "laser" = 75, "energy" = 25, "bomb" = 65, "bio" = 75, "rad" = 80, "fire" = 85, "acid" = 30, "wound" = 40)
+	armor = list("melee" = 72.5, "bullet" = 72.5, "laser" = 72.5, "energy" = 25, "bomb" = 65, "bio" = 75, "rad" = 80, "fire" = 85, "acid" = 30, "wound" = 40)
 //	armor_block_chance = 60
 //	deflection_chance = 10 //20% chance to block damage from blockable bullets and redirect the bullet at a random angle
 
@@ -460,42 +338,22 @@
 	icon_state = "t45dhelmet[light_on]"
 	item_state = "t45dhelmet[light_on]"
 
-/obj/item/clothing/head/helmet/f13/power_armor/t45d/gunslinger
-	name = "Gunslinger T-51b Helm"
-	desc = "(IX) With most of the external plating stripped to allow for internal thermal and night vision scanners, as well as aided targeting assist via onboard systems, this helm provides much more utility then protection. To support these systems, secondary power cells were installed into the helm, and covered with a stylish hat."
-	icon_state = "t51bgs"
-	item_state = "t51bgs"
-	slowdown = -0.2
-	flags_inv = HIDEEARS|HIDEEYES|HIDEFACE|HIDEFACIALHAIR
-	actions_types = list()
-
-/obj/item/clothing/head/helmet/f13/power_armor/t45d/sierra
-	name = "sierra power helmet"
-	desc = "(IX) A pre-war power armor helmet, issued to special NCR officers.."
-	icon_state = "sierra"
-	item_state = "sierra"
-	actions_types = list()
-
-/obj/item/clothing/head/helmet/f13/power_armor/midwest
-	name = "midwestern power helmet"
-	desc = "This helmet once belonged to the Midwestern branch of the Brotherhood of Steel, and now resides here."
-	icon_state = "midwestgrey_helm"
-	item_state = "midwestgrey_helm"
-	armor = list("melee" = 75, "bullet" = 75, "laser" = 80, "energy" = 27, "bomb" = 62, "bio" = 100, "rad" = 99, "fire" = 90, "acid" = 0, "wound" = 70)
-//	armor_block_chance = 60
-//	deflection_chance = 10 //20% chance to block damage from blockable bullets and redirect the bullet at a random angle
+/obj/item/clothing/head/helmet/f13/power_armor/hotrod
+	name = "hotrod T-45b power helmet"
+	desc = "This power armor helmet is so decrepit and battle-worn that it have lost most of its capability to protect the wearer from harm."
+	icon_state = "t45hotrod_helm"
+	item_state = "t45hotrod_helm"
+	armor = list("melee" = 55, "bullet" = 55, "laser" = 55, "energy" = 20, "bomb" = 50, "bio" = 60, "rad" = 50, "fire" = 80, "acid" = 0, "wound" = 40)
+	requires_training = FALSE
+	powered = FALSE
 
 /obj/item/clothing/head/helmet/f13/power_armor/t51b
 	name = "T-51b power helmet"
 	desc = "It's a T-51b power helmet, typically used by the Brotherhood. It looks somewhat charming."
 	icon_state = "t51bhelmet0"
 	item_state = "t51bhelmet0"
-	armor = list("melee" = 75, "bullet" = 75, "laser" = 75, "energy" = 27, "bomb" = 62, "bio" = 100, "rad" = 99, "fire" = 90, "acid" = 0, "wound" = 70)
+	armor = list("melee" = 70, "bullet" = 70, "laser" = 70, "energy" = 27, "bomb" = 62, "bio" = 100, "rad" = 99, "fire" = 90, "acid" = 0, "wound" = 70)
 	actions_types = list(/datum/action/item_action/toggle_helmet_light)
-//	armor_block_chance = 70
-//	deflection_chance = 10 //35% chance to block damage from blockable bullets and redirect the bullet at a random angle. Less overall armor compared to T-60, but higher deflection.
-//	armor_block_threshold = 0.25
-//	melee_block_threshold = 35
 
 /obj/item/clothing/head/helmet/f13/power_armor/t51b/update_icon_state()
 	icon_state = "t51bhelmet[light_on]"
@@ -509,27 +367,6 @@
 	icon_state = "t51bhelmet[light_on]"
 	item_state = "t51bhelmet[light_on]"
 
-/obj/item/clothing/head/helmet/f13/power_armor/t51b/wbos
-	name = "Washington power helmet"
-	desc = "It's a Washington Brotherhood power helmet. It looks somewhat terrifying."
-	icon_state = "t51wboshelmet"
-	item_state = "t51wboshelmet"
-	actions_types = list()
-
-/obj/item/clothing/head/helmet/f13/power_armor/t51b/reforgedwbos
-	name = "reforged Washington power helmet"
-	desc = "It's a reforged Washington Brotherhood power helmet, designed to induce fear in a target."
-	icon_state = "t51matthelmet"
-	item_state = "t51matthelmet"
-	actions_types = list()
-
-/obj/item/clothing/head/helmet/f13/power_armor/t51b/ultra
-	name = "Ultracite power helmet"
-	desc = "It's a T-51b power helmet, typically used by the Brotherhood. It looks somewhat charming. Now enhanced with ultracite."
-	icon_state = "ultracitepa_helm"
-	item_state = "ultracitepa_helm"
-	slowdown = 0
-	actions_types = list()
 
 /obj/item/clothing/head/helmet/f13/power_armor/t60
 	name = "T-60a power helmet"
@@ -538,10 +375,7 @@
 	item_state = "t60helmet0"
 	armor = list("melee" = 80, "bullet" = 70, "laser" = 80, "energy" = 30, "bomb" = 82, "bio" = 100, "rad" = 100, "fire" = 95, "acid" = 0, "wound" = 80)
 	actions_types = list(/datum/action/item_action/toggle_helmet_light)
-//	armor_block_chance = 80
-//	deflection_chance = 15 //20% chance to block damage from blockable bullets and redirect the bullet at a random angle. Same deflection as T-45 due to it having the same general shape.
-//	melee_block_threshold = 40
-//	armor_block_threshold = 0.3
+
 
 /obj/item/clothing/head/helmet/f13/power_armor/t60/update_icon_state()
 	icon_state = "t60helmet[light_on]"
@@ -549,69 +383,37 @@
 
 /obj/item/clothing/head/helmet/f13/power_armor/excavator
 	name = "excavator power helmet"
-	desc = "(VIII) The helmet of the excavator power armor suit."
+	desc = "The helmet of the excavator power armor suit."
 	icon_state = "excavator"
 	item_state = "excavator"
-	armor = list("tier" = 8, "energy" = 60, "bomb" = 62, "bio" = 100, "rad" = 90, "fire" = 90, "acid" = 0)
-//	armor_block_chance = 40
-//	deflection_chance = 10 //10% chance to block damage from blockable bullets and redirect the bullet at a random angle. Not a heavy combat model
+	armor = list("melee" = 80, "bullet" = 50, "laser" = 50, "energy" = 15, "bomb" = 100, "bio" = 100, "rad" = 100, "fire" = 95, "acid" = 80, "wound" = 80)
+
 
 /obj/item/clothing/head/helmet/f13/power_armor/advanced
 	name = "advanced power helmet"
-	desc = "(XII) It's an advanced power armor MK1 helmet, typically used by the Enclave. It looks somewhat threatening."
+	desc = "It's an advanced power armor MK1 helmet, typically used by the Enclave. It looks somewhat threatening."
 	icon_state = "advhelmet1"
 	item_state = "advhelmet1"
 	armor = list("melee" = 80, "bullet" = 80, "laser" = 85, "energy" = 35, "bomb" = 72, "bio" = 100, "rad" = 100, "fire" = 90, "acid" = 0, "wound" = 90)
-//	armor_block_threshold = 0.45
-//	melee_block_threshold = 45
-//	armor_block_chance = 80 //Enclave. 'nuff said
-//	deflection_chance = 15 //40% chance to block damage from blockable bullets and redirect the bullet at a random angle. Your ride's over mutie, time to die.
+
 
 /obj/item/clothing/head/helmet/f13/power_armor/advanced/hellfire
 	name = "hellfire power armor"
 	desc = "A deep black helmet of Enclave-manufactured heavy power armor with yellow ballistic glass, based on pre-war designs such as the T-51 and improving off of data gathered by post-war designs such as the X-01. Most commonly fielded on the East Coast, no other helmet rivals it's strength."
 	icon_state = "hellfirehelm"
 	item_state = "hellfirehelm"
-//	melee_block_threshold = 70
-//	armor_block_threshold = 0.8
-//	armor_block_chance = 99
-//	deflection_chance = 70
 	armor = list("melee" = 85, "bullet" = 85, "laser" = 87, "energy" = 37, "bomb" = 72, "bio" = 100, "rad" = 100, "fire" = 90, "acid" = 0, "wound" = 100)
 
-/obj/item/clothing/head/helmet/f13/power_armor/advanced/hellfire/wbos
-	name = "advanced Washington power helmet"
-	desc = "It's an improved model of the power armor helmet used exclusively by the Washington Brotherhood, designed to induce fear in a target."
-	icon_state = "t51wboshelmet"
-	item_state = "t51wboshelmet"
-
-/obj/item/clothing/head/helmet/f13/power_armor/tesla
-	name = "tesla power helmet"
-	desc = "A helmet typically used by Enclave special forces.<br>There are three orange energy capacitors on the side."
-	icon_state = "tesla"
-	item_state = "tesla"
-	armor = list("linemelee" = 200, "linebullet" = 200, "linelaser" = 300, "energy" = 95, "bomb" = 62, "bio" = 100, "rad" = 100, "fire" = 90, "acid" = 0, "wound" = 80)
-	var/hit_reflect_chance = 35
-
-/obj/item/clothing/head/helmet/f13/power_armor/tesla/run_block(mob/living/owner, atom/object, damage, attack_text, attack_type, armour_penetration, mob/attacker, def_zone, final_block_chance, list/block_return)
-	if(is_energy_reflectable_projectile(object) && (attack_type == ATTACK_TYPE_PROJECTILE) && (def_zone in protected_zones))
-		if(prob(hit_reflect_chance))
-			block_return[BLOCK_RETURN_REDIRECT_METHOD] = REDIRECT_METHOD_DEFLECT
-			return BLOCK_SHOULD_REDIRECT | BLOCK_REDIRECTED | BLOCK_SUCCESS | BLOCK_PHYSICAL_INTERNAL
-	return ..()
 
 //Part of the peacekeeper enclave stuff, adjust values as needed.
 /obj/item/clothing/head/helmet/f13/power_armor/x02helmet
 	name = "Enclave power armor helmet"
-	desc = "(XI) The Enclave Mark II Powered Combat Armor helmet."
+	desc = "The Enclave Mark II Powered Combat Armor helmet."
 	icon_state = "advanced"
 	item_state = "advanced"
 	slowdown = 0.1
-	armor = list("tier" = 11, "energy" = 65, "bomb" = 62, "bio" = 100, "rad" = 99, "fire" = 90, "acid" = 0, "wound" = 70)
+	armor = list("melee" = 85, "bullet" = 85, "laser" = 87, "energy" = 65, "bomb" = 62, "bio" = 100, "rad" = 99, "fire" = 90, "acid" = 0, "wound" = 70)
 	actions_types = list(/datum/action/item_action/toggle_helmet_light)
-//	armor_block_threshold = 0.45
-//	melee_block_threshold = 45
-//	armor_block_chance = 80
-//	deflection_chance = 15
 
 
 //Generic Tribal - For Wayfarer specific, see f13factionhead.dm

--- a/code/modules/clothing/suits/f13armor.dm
+++ b/code/modules/clothing/suits/f13armor.dm
@@ -293,13 +293,14 @@
 		return
 	if(!powered)
 		return
-	if(isliving(loc))
+	if(isliving(loc) && prob(severity*1.5))
+		var/time_slowed = severity / 10 SECONDS
 		var/mob/living/L = loc
 		to_chat(L, "<span class='warning'>Warning: electromagnetic surge detected in armor. Rerouting power to emergency systems.</span>")
 		slowdown += 1.2
 		if(istype(L))
 			L.update_equipment_speed_mods()
-		addtimer(CALLBACK(src, .proc/end_emp_effect), 5 SECONDS)
+		addtimer(CALLBACK(src, .proc/end_emp_effect), time_slowed)
 
 /obj/item/clothing/suit/armor/f13/power_armor/proc/end_emp_effect()
 	if(isliving(loc))

--- a/code/modules/clothing/suits/f13armor.dm
+++ b/code/modules/clothing/suits/f13armor.dm
@@ -262,84 +262,8 @@
 	max_heat_protection_temperature = FIRE_SUIT_MAX_TEMP_PROTECT
 	cold_protection = CHEST|GROIN|LEGS|FEET|ARMS|HANDS
 	min_cold_protection_temperature = FIRE_SUIT_MIN_TEMP_PROTECT
-	var/emped = 0
 	var/requires_training = TRUE
 	var/powered = TRUE
-	var/armor_block_chance = 0 //Chance for the power armor to block a low penetration projectile
-	protected_zones = list(BODY_ZONE_CHEST, BODY_ZONE_PRECISE_GROIN, BODY_ZONE_L_ARM, BODY_ZONE_R_ARM, BODY_ZONE_L_LEG, BODY_ZONE_R_LEG)
-	var/deflection_chance = 0 //Chance for the power armor to redirect a blocked projectile
-	var/armor_block_threshold = 0 //projectiles below this will deflect
-	var/melee_block_threshold = 0
-	var/dmg_block_threshold = 0
-	var/powerLevel = 7000
-	var/powerMode = 3
-
-/obj/item/fusion_fuel
-	name = "fusion fuel cell"
-	desc = "Some fusion fuel used to recharge the fusion cores of Power Armor."
-	icon = 'icons/obj/power.dmi'
-	icon_state = "cell"
-	item_state = "cell"
-	lefthand_file = 'icons/mob/inhands/misc/devices_lefthand.dmi'
-	righthand_file = 'icons/mob/inhands/misc/devices_righthand.dmi'
-	var/fuel = 20000
-
-/obj/item/fusion_fuel/examine(mob/user)
-	. = ..()
-	to_chat(user, "The charge meter reads [fuel].")
-
-/obj/item/clothing/suit/armor/f13/power_armor/attackby(obj/item/I, mob/user, params)
-	. = ..()
-	if(istype(I,/obj/item/fusion_fuel)&& powered)
-		var/obj/item/fusion_fuel/fuel = I
-		if(src.powerLevel>=50000)
-			to_chat(user, "The fusion core is full.")
-			return
-		if(fuel.fuel >= 5000)
-			src.powerLevel += 5000
-			fuel.fuel -= 5000
-			to_chat(user, "You charge the fusion core to [src.powerLevel] units of fuel. [fuel.fuel]/20000 left in the fuel cell.")
-			return
-		to_chat(user, "The fuel cell is empty.")
-
-/obj/item/clothing/suit/armor/f13/power_armor/proc/processPower()
-	if(powerLevel>0)//drain charge
-		powerLevel -= 1
-	if(powerLevel > 20000)//switch to 3 power mode
-		if(powerMode <= 2)
-			powerUp()
-		return
-	if(powerLevel > 10000)//switch to 2 power
-		if(powerMode <= 1)
-			powerUp()
-		if(powerMode > 2)
-			powerDown()
-		return
-	if(powerLevel > 5000)//switch to 1 power
-		if(powerMode <= 0)
-			powerUp()
-		if(powerMode > 1)
-			powerDown()
-		return
-	if(powerLevel >= 0)//switch to 0 power
-		if(powerMode >= 1)
-			powerDown()
-
-/obj/item/clothing/suit/armor/f13/power_armor/proc/powerUp(mob/user)
-	powerMode += 1
-	slowdown -= 0.2
-	var/mob/living/L = loc
-	if(istype(L))
-		L.update_equipment_speed_mods()
-	armor = armor.modifyRating(melee = 75, bullet = 75, laser = 75)
-
-/obj/item/clothing/suit/armor/f13/power_armor/proc/powerDown(mob/user)
-	powerMode -= 1
-	slowdown += 0.2
-	var/mob/living/L = loc
-	if(istype(L))
-		L.update_equipment_speed_mods()
-	armor = armor.modifyRating(melee = -75, bullet = -75, laser = -75)
 
 /obj/item/clothing/suit/armor/f13/power_armor/mob_can_equip(mob/user, mob/equipper, slot, disable_warning = 1)
 	var/mob/living/carbon/human/H = user
@@ -348,59 +272,43 @@
 	if (!HAS_TRAIT(H, TRAIT_PA_WEAR) && slot == SLOT_WEAR_SUIT && requires_training)
 		to_chat(user, "<span class='warning'>You don't have the proper training to operate the power armor!</span>")
 		return 0
-	if(slot == SLOT_WEAR_SUIT)
-		ADD_TRAIT(user, TRAIT_STUNIMMUNE,	"stun_immunity")
-		ADD_TRAIT(user, TRAIT_PUSHIMMUNE,	"push_immunity")
+	if(slot == SLOT_WEAR_SUIT && powered)
+		ADD_TRAIT(user, TRAIT_STUNIMMUNE,	"PA_stun_immunity")
+		ADD_TRAIT(user, TRAIT_PUSHIMMUNE,	"PA_push_immunity")
+		ADD_TRAIT(user, SPREAD_CONTROL,	"PA_spreadcontrol")
+
 		return ..()
 	return
 
 /obj/item/clothing/suit/armor/f13/power_armor/dropped(mob/user)
-	REMOVE_TRAIT(user, TRAIT_STUNIMMUNE,	"stun_immunity")
-	REMOVE_TRAIT(user, TRAIT_PUSHIMMUNE,	"push_immunity")
+	if(powered)
+		REMOVE_TRAIT(user, TRAIT_STUNIMMUNE,	"PA_stun_immunity")
+		REMOVE_TRAIT(user, TRAIT_PUSHIMMUNE,	"PA_push_immunity")
+		REMOVE_TRAIT(user, SPREAD_CONTROL,	"PA_spreadcontrol")
 	return ..()
 
 /obj/item/clothing/suit/armor/f13/power_armor/emp_act(mob/living/carbon/human/owner, severity)
 	. = ..()
 	if(. & EMP_PROTECT_SELF)
 		return
-	emped++
-	var/curremp = emped // keeps tabs on the current EMP cycle.
-	if(ismob(loc))
+	if(!powered)
+		return
+	if(isliving(loc))
 		var/mob/living/L = loc
-		to_chat(loc, "<span class='warning'>Warning: electromagnetic surge detected in armor. Rerouting power to emergency systems.</span>")
+		to_chat(L, "<span class='warning'>Warning: electromagnetic surge detected in armor. Rerouting power to emergency systems.</span>")
 		slowdown += 1.2
-		armor = armor.modifyRating(melee = -100, bullet = -100, laser = -100)
 		if(istype(L))
 			L.update_equipment_speed_mods()
-		addtimer(CALLBACK(src, .proc/end_emp_effect, curremp), 5 SECONDS)
+		addtimer(CALLBACK(src, .proc/end_emp_effect), 5 SECONDS)
 
-/obj/item/clothing/suit/armor/f13/power_armor/proc/end_emp_effect(curremp)
-	if(emped != curremp) //Don't fix it if it's been EMP'd again
-		return FALSE
-	if(ismob(loc))
+/obj/item/clothing/suit/armor/f13/power_armor/proc/end_emp_effect()
+	if(isliving(loc))
 		var/mob/living/L = loc
-		armor = armor.modifyRating(melee = 100, bullet = 100, laser = 100)
 		slowdown -= 1.2
-		to_chat(loc, "<span class='warning'>Armor power reroute successful. All systems operational.</span>")
+		to_chat(L, "<span class='warning'>Armor power reroute successful. All systems operational.</span>")
 		if(istype(L))
 			L.update_equipment_speed_mods()
 	return TRUE
-
-/obj/item/clothing/suit/armor/f13/power_armor/run_block(mob/living/owner, atom/object, damage, attack_text, attack_type, armour_penetration, mob/attacker, def_zone, final_block_chance, list/block_return)
-	. = ..()
-	if(damage >= src.dmg_block_threshold && check_armor_penetration(object) >= 0)
-		return
-	if(check_armor_penetration(object) <= src.armor_block_threshold && (attack_type == ATTACK_TYPE_PROJECTILE) && (def_zone in protected_zones))
-		if(prob(armor_block_chance))
-			var/ratio = rand(0,100)
-			if(ratio <= deflection_chance)
-				block_return[BLOCK_RETURN_REDIRECT_METHOD] = REDIRECT_METHOD_DEFLECT
-				return BLOCK_SHOULD_REDIRECT | BLOCK_REDIRECTED | BLOCK_SUCCESS | BLOCK_PHYSICAL_INTERNAL
-			if(ismob(loc))
-				to_chat(loc, "<span class='warning'>Your power armor absorbs the projectile's impact!</span>")
-			block_return[BLOCK_RETURN_SET_DAMAGE_TO] = 0
-			return BLOCK_SUCCESS | BLOCK_PHYSICAL_INTERNAL
-	return
 
 /obj/item/clothing/suit/armor/f13/power_armor/t45b
 	name = "salvaged T-45b power armor"
@@ -446,29 +354,13 @@
 	slowdown = 0.25
 	requires_training = FALSE
 
-/obj/item/clothing/suit/armor/f13/power_armor/vaulttec
-	name = "Vault-Tec power armour"
-	desc = "A refined suit of power armour, purpose-built by the residents of Vault-115 in order to better keep the peace in their new settlement."
-	icon_state = "vaultpa"
-	item_state = "vaultpa"
-	armor = list("melee" = 65, "bullet" = 65, "laser" = 65, "energy" = 22, "bomb" = 55, "bio" = 65, "rad" = 55, "fire" = 85, "acid" = 0, "wound" = 70)
-	slowdown = 0
-
-/obj/item/clothing/suit/armor/f13/power_armor/vaulttecta
-	name = "Vault-Tec technical armour"
-	desc = "A primative  suit of power armour, the first kind built by the residents of Vault-115 in order to fight off immediate threats."
-	icon_state = "vaulttecta"
-	item_state = "vaulttecta"
-	armor = list("melee" = 60, "bullet" = 60, "laser" = 60, "energy" = 25, "bomb" = 55, "bio" = 65, "rad" = 55, "fire" = 85, "acid" = 0, "wound" = 70)
-	slowdown = 0.4
-
 /obj/item/clothing/suit/armor/f13/power_armor/excavator
 	name = "excavator power armor"
 	desc = "Developed by Garrahan Mining Co. in collaboration with West Tek, the Excavator-class power armor was designed to protect miners from rockfalls and airborne contaminants while increasing the speed at which they could work. "
 	icon_state = "excavator"
 	item_state = "excavator"
-	slowdown = 0.5
-	armor = list("melee" = 70, "bullet" = 50, "laser" = 50, "energy" = 25, "bomb" = 80, "bio" = 65, "rad" = 55, "fire" = 85, "acid" = 0, "wound" = 40)
+	slowdown = 0.4
+	armor = list("melee" = 80, "bullet" = 50, "laser" = 50, "energy" = 15, "bomb" = 100, "bio" = 100, "rad" = 100, "fire" = 95, "acid" = 80, "wound" = 80)
 
 /obj/item/clothing/suit/armor/f13/power_armor/t45d
 	name = "T-45d power armor"
@@ -476,22 +368,7 @@
 	icon_state = "t45dpowerarmor"
 	item_state = "t45dpowerarmor"
 	slowdown = 0.225
-	armor = list("melee" = 73, "bullet" = 73, "laser" = 73, "energy" = 25, "bomb" = 65, "bio" = 75, "rad" = 80, "fire" = 85, "acid" = 30, "wound" = 70)
-
-
-/obj/item/clothing/suit/armor/f13/power_armor/t45d/gunslinger
-	name = "Gunslinger T-51b"
-	desc = "(IX) What was once a suit of T-51 Power Armor is now an almost unrecognizable piece of art or garbage, depending on who you ask. Almost all of the external plating has either been removed or stripped to allow for maximum mobility, and overlapping underplates protect the user from small arms fire. Whoever designed this had a very specific purpose in mind: mobility and aesthetics over defense."
-	icon_state = "t51bgs"
-	item_state = "t51bgs"
-	slowdown = -0.2
-	flags_inv = HIDEJUMPSUIT|HIDENECK
-
-/obj/item/clothing/suit/armor/f13/power_armor/t45d/sierra
-	name = "sierra power armor"
-	desc = "A captured set of T-45d power armor put into use by the NCR, it's been heavily modified and decorated with the head of a bear and intricate gold trimming. A two headed bear is scorched into the breastplate."
-	icon_state = "sierra"
-	item_state = "sierra"
+	armor = list("melee" = 72.5, "bullet" = 72.5, "laser" = 72.5, "energy" = 25, "bomb" = 65, "bio" = 75, "rad" = 80, "fire" = 85, "acid" = 30, "wound" = 70)
 
 /obj/item/clothing/suit/armor/f13/power_armor/t45d/knightcaptain
 	name = "Head-Knight's T-45d Power Armour"
@@ -506,20 +383,13 @@
 	icon_state = "t45dpowerarmor_bos"
 	item_state = "t45dpowerarmor_bos"
 
-/obj/item/clothing/suit/armor/f13/power_armor/midwest
-	name = "midwestern power armor"
-	desc = "This set of power armor once belonged to the Midwestern branch of the Brotherhood of Steel, and now resides here."
-	icon_state = "midwestgrey_pa"
-	item_state = "midwestgrey_pa"
-	armor = list("melee" = 75, "bullet" = 70, "laser" = 45, "energy" = 25, "bomb" = 65, "bio" = 75, "rad" = 80, "fire" = 85, "acid" = 30, "wound" = 70)
-
 /obj/item/clothing/suit/armor/f13/power_armor/t51b
 	name = "T-51b power armor"
 	desc = "The pinnacle of pre-war technology. This suit of power armor provides substantial protection to the wearer."
 	icon_state = "t51bpowerarmor"
 	item_state = "t51bpowerarmor"
 	slowdown = 0.15 //+0.05 from helmet = total 0.175
-	armor = list("melee" = 73, "bullet" = 73, "laser" = 73, "energy" = 30, "bomb" = 62, "bio" = 100, "rad" = 99, "fire" = 90, "acid" = 0, "wound" = 72)
+	armor = list("melee" = 72.5, "bullet" = 72.5, "laser" = 72.5, "energy" = 30, "bomb" = 62, "bio" = 100, "rad" = 99, "fire" = 90, "acid" = 0, "wound" = 72)
 
 /obj/item/clothing/suit/armor/f13/power_armor/t51green
 	name = "Hardened T-51b power armor"
@@ -535,33 +405,6 @@
 	icon_state = "t51bpowerarmor_bos"
 	item_state = "t51bpowerarmor_bos"
 
-/obj/item/clothing/suit/armor/f13/power_armor/t51b/tesla
-	name = "T-51b tesla armor"
-	desc = "The pinnacle of pre-war technology. This suit of power armor provides substantial protection to the wearer, with the added benefit of tesla coils."
-	icon_state = "t51tesla"
-	item_state = "t51tesla"
-	slowdown = 0.15 //+0.1 from helmet = total 0.25
-	armor = list("melee" = 70, "bullet" = 70, "laser" = 85, "energy" = 70, "bomb" = 62, "bio" = 100, "rad" = 99, "fire" = 90, "acid" = 0, "wound" = 72)
-
-/obj/item/clothing/suit/armor/f13/power_armor/t51b/wbos
-	name = "Washington power armor"
-	desc = "A dark mirror to the pinnacle of pre-war technology. This suit of power armor provides substantial protection to the wearer."
-	icon_state = "t51wbos"
-	item_state = "t51wbos"
-
-/obj/item/clothing/suit/armor/f13/power_armor/t51b/reforgedwbos
-	name = "reforged Washington power armor"
-	desc = "A dark mirror to the pinnacle of pre-war technology, reforged. This suit of power armor provides substantial protection to the wearer."
-	icon_state = "t51matt"
-	item_state = "t51matt"
-
-/obj/item/clothing/suit/armor/f13/power_armor/t51b/ultra
-	name = "Ultracite power armor"
-	desc = "(X) The pinnacle of pre-war technology. This suit of power armor provides substantial protection to the wearer. Now ultracite enhanced."
-	icon_state = "ultracitepa"
-	item_state = "ultracitepa"
-	slowdown = 0
-
 /obj/item/clothing/suit/armor/f13/power_armor/t60
 	name = "T-60a power armor"
 	desc = "Developed in early 2077 after the Anchorage Reclamation, the T-60 series of power armor was designed to eventually replace the T-51b as the pinnacle of powered armor technology in the U.S. military arsenal."
@@ -570,22 +413,6 @@
 	slowdown = 0.1
 	armor = list("melee" = 80, "bullet" = 70, "laser" = 80, "energy" = 30, "bomb" = 82, "bio" = 100, "rad" = 100, "fire" = 95, "acid" = 0, "wound" = 80)
 
-/obj/item/clothing/suit/armor/f13/power_armor/t60/tesla
-	name = "T-60b tesla armor"
-	desc = "(X*) An experimental variant of T-60a power armor featuring an array of tesla coils. A small amount of protection has been sacrificed to give a chance to deflect energy projectiles."
-	icon_state = "t60tesla"
-	item_state = "t60tesla"
-	slowdown = 0.1
-	armor = list("tier" = 10, "linelaser" = 25, "energy" = 70, "bomb" = 82, "bio" = 100, "rad" = 100, "fire" = 95, "acid" = 0, "wound" = 80)
-	var/hit_reflect_chance = 20
-
-/obj/item/clothing/suit/armor/f13/power_armor/t60/tesla/run_block(mob/living/owner, atom/object, damage, attack_text, attack_type, armour_penetration, mob/attacker, def_zone, final_block_chance, list/block_return)
-	if(is_energy_reflectable_projectile(object) && (attack_type == ATTACK_TYPE_PROJECTILE) && (def_zone in protected_zones))
-		if(prob(hit_reflect_chance))
-			block_return[BLOCK_RETURN_REDIRECT_METHOD] = REDIRECT_METHOD_DEFLECT
-			return BLOCK_SHOULD_REDIRECT | BLOCK_REDIRECTED | BLOCK_SUCCESS | BLOCK_PHYSICAL_INTERNAL
-	return ..()
-
 /obj/item/clothing/suit/armor/f13/power_armor/advanced
 	name = "advanced power armor"
 	desc = "An advanced suit of armor typically used by the Enclave.<br>It is composed of lightweight metal alloys, reinforced with ceramic castings at key stress points.<br>Additionally, like the T-51b power armor, it includes a recycling system that can convert human waste into drinkable water, and an air conditioning system for its user's comfort."
@@ -593,42 +420,14 @@
 	item_state = "advpowerarmor1"
 	armor = list("melee" = 80, "bullet" = 80, "laser" = 85, "energy" = 35, "bomb" = 72, "bio" = 100, "rad" = 100, "fire" = 90, "acid" = 0, "wound" = 90)
 
-/obj/item/clothing/suit/armor/f13/power_armor/advanced/hellfire
-	name = "hellfire power armor"
-	desc = "A deep black suit of Enclave-manufactured heavy power armor, based on pre-war designs such as the T-51 and improving off of data gathered by post-war designs such as the X-01. Most commonly fielded on the East Coast, no suit rivals it's strength."
-	icon_state = "hellfire"
-	item_state = "hellfire"
-	armor = list("melee" = 85, "bullet" = 85, "laser" = 90, "energy" = 37, "bomb" = 72, "bio" = 100, "rad" = 100, "fire" = 90, "acid" = 0, "wound" = 100)
-
-/obj/item/clothing/suit/armor/f13/power_armor/advanced/hellfire/wbos
-	name = "advanced Washington power armor"
-	desc = "It's an improved model of the power armor used exclusively by the Washington Brotherhood."
-	icon_state = "apawbos"
-	item_state = "apawbos"
-
-/obj/item/clothing/suit/armor/f13/power_armor/tesla
-	name = "tesla power armor"
-	desc = "A variant of the Enclave's advanced power armor Mk I, jury-rigged with a Tesla device that is capable of dispersing a large percentage of the damage done by directed-energy attacks.<br>As it's made of complex composite materials designed to block most of energy damage - it's notably weaker against kinetic impacts."
-	icon_state = "tesla"
-	item_state = "tesla"
-	armor = list("melee" = 65, "bullet" = 65, "laser" = 90, "energy" = 95, "bomb" = 62, "bio" = 100, "rad" = 100, "fire" = 90, "acid" = 0, "wound" = 80)
-	var/hit_reflect_chance = 35
-
-/obj/item/clothing/suit/armor/f13/power_armor/tesla/run_block(mob/living/owner, atom/object, damage, attack_text, attack_type, armour_penetration, mob/attacker, def_zone, final_block_chance, list/block_return)
-	if(is_energy_reflectable_projectile(object) && (attack_type == ATTACK_TYPE_PROJECTILE) && (def_zone in protected_zones))
-		if(prob(hit_reflect_chance))
-			block_return[BLOCK_RETURN_REDIRECT_METHOD] = REDIRECT_METHOD_DEFLECT
-			return BLOCK_SHOULD_REDIRECT | BLOCK_REDIRECTED | BLOCK_SUCCESS | BLOCK_PHYSICAL_INTERNAL
-	return ..()
-
 //Peacekeeper armor adjust as needed
 /obj/item/clothing/suit/armor/f13/power_armor/x02
 	name = "Enclave power armor"
-	desc = "(XI) Upgraded pre-war power armor design used by the Enclave. It is mildly worn due to it's age and lack of maintenance after the fall of the Enclave."
+	desc = "Upgraded pre-war power armor design used by the Enclave. It is mildly worn due to it's age and lack of maintenance after the fall of the Enclave."
 	icon_state = "advanced"
 	item_state = "advanced"
 	slowdown = 0.15 //+0.1 from helmet = total 0.25
-	armor = list("tier" = 11, "energy" = 65, "bomb" = 62, "bio" = 100, "rad" = 99, "fire" = 90, "acid" = 0, "wound" = 70)
+	armor = list("melee" = 85, "bullet" = 85, "laser" = 87, "energy" = 65, "bomb" = 62, "bio" = 100, "rad" = 99, "fire" = 90, "acid" = 0, "wound" = 70)
 
 /obj/item/clothing/suit/armor/f13/enclave/armorvest
 	name = "armored vest"

--- a/code/modules/jobs/job_types/ncr.dm
+++ b/code/modules/jobs/job_types/ncr.dm
@@ -87,11 +87,11 @@ Weapons		Service Rifle, Grease Gun, 9mm pistol, all good.
 	uniform	= /obj/item/clothing/under/f13/ncr/ncr_officer
 	shoes = /obj/item/clothing/shoes/f13/military/ncr_officer_boots
 	accessory = /obj/item/clothing/accessory/ncr
-	head = /obj/item/clothing/head/helmet/f13/power_armor/t45d/sierra
+	head = /obj/item/clothing/head/helmet/f13/power_armor/t45d
 	neck = /obj/item/storage/belt/holster/legholster
 	glasses = /obj/item/clothing/glasses/sunglasses/big
 	gloves = /obj/item/clothing/gloves/f13/leather
-	suit = /obj/item/clothing/suit/armor/f13/power_armor/t45d/sierra
+	suit = /obj/item/clothing/suit/armor/f13/power_armor/t45d
 	r_pocket = /obj/item/binoculars
 	suit_store = /obj/item/gun/ballistic/automatic/pistol/deagle
 	backpack_contents = list(

--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -448,6 +448,7 @@ ATTACHMENTS
 				addtimer(CALLBACK(G, /obj/item/gun.proc/process_fire, target, user, TRUE, params, null, bonus_spread, stam_cost), loop_counter)
 
 	var/stam_cost = getstamcost(user)
+
 	process_fire(target, user, TRUE, params, null, bonus_spread, stam_cost)
 
 /obj/item/gun/can_trigger_gun(mob/living/user)
@@ -522,7 +523,9 @@ ATTACHMENTS
 	else if(burst_size > 1 && burst_spread)
 		randomized_gun_spread = rand(0, burst_spread)
 	var/randomized_bonus_spread = rand(0, bonus_spread)
-
+	if(HAS_TRAIT(user, SPREAD_CONTROL))
+		randomized_gun_spread = max(0, randomized_gun_spread-8)
+		randomized_bonus_spread = max(0, randomized_bonus_spread-8)
 	if(burst_size > 1)
 		do_burst_shot(user, target, message, params, zone_override, sprd, randomized_gun_spread, randomized_bonus_spread, rand_spr, 1)
 		for(var/i in 2 to burst_size)

--- a/modular_citadel/code/game/objects/cit_screenshake.dm
+++ b/modular_citadel/code/game/objects/cit_screenshake.dm
@@ -7,6 +7,8 @@
 	var/client/C = M.client
 	if (C.prefs.screenshake==0)
 		return
+	if(HAS_TRAIT(M, TRAIT_NO_SCREENSHAKE))
+		return
 	var/oldx = C.pixel_x
 	var/oldy = C.pixel_y
 	var/clientscreenshake = (C.prefs.screenshake * 0.01)

--- a/modular_citadel/code/game/objects/cit_screenshake.dm
+++ b/modular_citadel/code/game/objects/cit_screenshake.dm
@@ -7,8 +7,6 @@
 	var/client/C = M.client
 	if (C.prefs.screenshake==0)
 		return
-	if(HAS_TRAIT(M, TRAIT_NO_SCREENSHAKE))
-		return
 	var/oldx = C.pixel_x
 	var/oldy = C.pixel_y
 	var/clientscreenshake = (C.prefs.screenshake * 0.01)


### PR DESCRIPTION
no atomization because its cringe

PA now reduces weapon spread when worn. this was going to be accompanied with a -5% armor from 75 to 70 but someone already did that

## Pre-Merge Checklist
<!-- Don't bother filling these in while creating your Pull Request, just click the checkboxes after the Pull Request is opened and you are redirected to the page. -->
- [ ] You tested this on a local server.
- [ ] This code did not runtime during testing.
- [ ] You documented all of your changes.
<!-- Neither the compiler nor workflow checks are perfect at detecting runtimes and errors. It is important to test your code/feature/fix locally. -->


## Changelog

:cl:
del: removes most unused PA (sprites still exist, admins can create them via varediting)
balance: EMPing PA no longer makes u take 200% damage, EMP duration is now based on severity, with max duration up to 10 seconds if you eat a pointblank one
balance: PA now reduces weapon spread when worn
balance: headset EMPs are now chance-based on EMP severity
/:cl:

