### PR TITLE
General Weapons Adjustments

### DIFF
--- a/code/modules/projectiles/guns/ballistic/automatic.dm
+++ b/code/modules/projectiles/guns/ballistic/automatic.dm
@@ -1209,9 +1209,8 @@
 	lefthand_file = 'icons/fallout/onmob/weapons/guns_lefthand.dmi'
 	righthand_file = 'icons/fallout/onmob/weapons/guns_righthand.dmi'
 	icon_state = "rifle-police"
-	extra_damage = 22 //longer barrel
 	autofire_shot_delay = 3.5 //not a real auto-gun
-	spread = 8 //longer barrel
+	spread = 12 //makeshift longer barrel
 	can_scope = TRUE
 	
 /obj/item/gun/ballistic/automatic/assault_carbine/worn	

--- a/code/modules/projectiles/guns/ballistic/automatic.dm
+++ b/code/modules/projectiles/guns/ballistic/automatic.dm
@@ -210,10 +210,10 @@
 	can_unsuppress = FALSE
 	is_automatic = TRUE
 	automatic = 1
-	autofire_shot_delay = 1.5
+	autofire_shot_delay = 1.75
 	spread = 18
 	burst_shot_delay = 1.5
-	extra_damage = 16
+	extra_damage = 10
 	suppressed = 1
 	actions_types = null
 	fire_sound = 'sound/f13weapons/american180.ogg'

--- a/code/modules/projectiles/guns/ballistic/automatic.dm
+++ b/code/modules/projectiles/guns/ballistic/automatic.dm
@@ -1040,13 +1040,14 @@
 	icon_state = "assault_rifle"
 	item_state = "fnfal"
 	mag_type = /obj/item/ammo_box/magazine/m556/rifle
-	fire_delay = 4
+	fire_delay = 2.5
+	slowdown = 0.45
 	spread = 10
 	extra_damage = 23
 	recoil = 0.1
 	is_automatic = TRUE
 	automatic = 1
-	autofire_shot_delay = 3
+	autofire_shot_delay = 2.5
 	can_attachments = TRUE
 	can_bayonet = FALSE
 	bayonet_state = "rifles"

--- a/code/modules/projectiles/guns/ballistic/automatic.dm
+++ b/code/modules/projectiles/guns/ballistic/automatic.dm
@@ -767,9 +767,8 @@
 	name = "scout carbine"
 	desc = "A cut down version of the standard-issue service rifle tapped with mounting holes for a scope. Shorter barrel, lower muzzle velocity."
 	icon_state = "scout_carbine"
-	fire_delay = 4
-	spread = 1.1
-	slowdown = 0.4
+	spread = 1.2
+	slowdown = 0.3
 	extra_damage = 25
 	can_scope = TRUE
 	scope_state = "scope_short"

--- a/code/modules/projectiles/guns/ballistic/automatic.dm
+++ b/code/modules/projectiles/guns/ballistic/automatic.dm
@@ -992,8 +992,8 @@
 	fire_delay = 8
 	burst_size = 1
 	extra_speed = 800
-	extra_penetration = 0.25
-	extra_damage = 45
+	extra_penetration = 0.2
+	extra_damage = 35
 	zoom_amt = 10
 	zoom_out_amt = 13
 	semi_auto = TRUE

--- a/code/modules/projectiles/guns/ballistic/minigun.dm
+++ b/code/modules/projectiles/guns/ballistic/minigun.dm
@@ -96,7 +96,7 @@
 	w_class = WEIGHT_CLASS_HUGE
 	burst_size = 1
 	automatic = 1
-	autofire_shot_delay = 2.15
+	autofire_shot_delay = 1
 	burst_shot_delay = 1
 	fire_delay = 1
 	ranged_attack_speed = CLICK_CD_RAPID

--- a/code/modules/projectiles/guns/ballistic/rifle.dm
+++ b/code/modules/projectiles/guns/ballistic/rifle.dm
@@ -259,9 +259,9 @@
 	icon_state = "enfield2"
 	item_state = "308"
 	mag_type = /obj/item/ammo_box/magazine/internal/boltaction
-	extra_damage = 37
+	extra_damage = 40
 	extra_speed = 600
-	fire_delay = 7
+	fire_delay = 6
 	slowdown = 0.35
 	force = 16
 	can_scope = TRUE

--- a/code/modules/projectiles/guns/ballistic/rifle.dm
+++ b/code/modules/projectiles/guns/ballistic/rifle.dm
@@ -99,6 +99,7 @@
 	can_scope = TRUE
 	scope_state = "scope_long"
 	fire_delay = 5
+	slowdown = 0.35
 	scope_x_offset = 5
 	scope_y_offset = 13
 	pump_sound = 'sound/f13weapons/cowboyrepeaterreload.ogg'
@@ -116,6 +117,7 @@
 	item_state = "cowboyrepeater"
 	mag_type = /obj/item/ammo_box/magazine/internal/shot/tube357
 	extra_damage = 35
+	extra_speed = 300
 	fire_sound = 'sound/f13weapons/cowboyrepeaterfire.ogg'
 
 
@@ -127,6 +129,7 @@
 	item_state = "trailcarbine"
 	mag_type = /obj/item/ammo_box/magazine/internal/shot/tube44
 	extra_damage = 40
+	extra_speed = 200
 	fire_sound = 'sound/f13weapons/44mag.ogg'
 
 
@@ -139,6 +142,7 @@
 	mag_type = /obj/item/ammo_box/magazine/internal/shot/tube4570
 	extra_damage = 50
 	extra_penetration = 0.05
+	extra_speed = 100
 	fire_delay = 5.1
 	recoil = 0.15
 	fire_sound = 'sound/f13weapons/brushgunfire.ogg'

--- a/code/modules/projectiles/guns/energy/laser.dm
+++ b/code/modules/projectiles/guns/energy/laser.dm
@@ -603,7 +603,7 @@
 	burst_size = 1
 	burst_shot_delay = 1
 	automatic = 1
-	autofire_shot_delay = 2.5
+	autofire_shot_delay = 1.75
 	spread = 8
 	fire_delay = 1
 	weapon_weight = WEAPON_HEAVY

--- a/code/modules/projectiles/projectile/beams.dm
+++ b/code/modules/projectiles/projectile/beams.dm
@@ -490,7 +490,7 @@
 /obj/item/projectile/beam/laser/rcw/hitscan //RCW
 	name = "rapidfire beam"
 	icon_state = "emitter"
-	damage = 25 //ALWAYS does 50, this is a burstfire hitscan weapon that fires in bursts of 2.
+	damage = 15 //ALWAYS does 50, this is a burstfire hitscan weapon that fires in bursts of 2.
 	hitscan = TRUE
 	muzzle_type = /obj/effect/projectile/muzzle/laser/emitter
 	tracer_type = /obj/effect/projectile/tracer/laser/emitter


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

<!-- NOTE: This format is NOT REQUIRED for things like runtime fixes, code fixes and optimizations. In those instances you should try to give a description of what is being fixed or optimized but are not required to fill out the complete changelog. -->
<!-- Adjusting things like armor or weapon values for balance, while they may be 'fixes' in their own way, are not considered code fixes as described above and require the use of the Pull Request format below.-->


## About The Pull Request
I couldn't come up with an added alliteratively appealing title. I am sad.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Scout rifle: 
Increases the spread on the scout carbine and reduces its slowdown to match SMGs as it's supposed to scout. I also removed the fire_delay preventing it from inheriting the service rifle's fire rate buff.

Repeaters:
Currently, there's no good reason on why you should take a repeater over automatics or double revolvers. This gives repeaters a niche where they have slowdown inbetween SMGs and other rifles. The bullet speed increase also lets them perform better at using their weapons optics. Cowboy repeater gets the fastest bullet speed as it has the weakest damage out of three.

Police rifles:
Police rifles are easily made by shopkeepers and despite this, they somehow perform better than assault carbines. An automatic rifle held together by duct tape and good wishes does more damage and has lower spread than a pre-war rifle. This has been changed.

American 180:
The American 180 is currently a superior minigun. A fraction of the slowdown, easier to reload, easier to obtain, can carry up to 7 magazines of 180 bullets each, more damage, and faster fire rate. Fuck that noise. Nerfs damage and fire rate but it'll still fire faster than its closest SMG peer by .25.

Minigun:
Minigun is shit. Ideally, this makes it not shit. Fire rate buff. Ideally, the result will be that it does a lot of chip damage and stop people from advancing. It might need some tweaking but we'll go from here.

R91:
The R91 has a lot of competitors and it underperforms compared to its peers. Buffing its fire rate and making the slowdown consistent with service rifle and R82 should give it a tangible niche of being able to clear rooms comparable to SMGs or suppress on open fields.

RCW:
RCW currently fires 25 damage beams at an autofire delay of 2. It's also hitscan. The wasteland barely has laser protection. A squad of Knights with RCWs can roll up on anyone and delete them from existence. Damage is reduced.

Gatling laser:
Gatling laser is also bad because it fires slow as heck. Should be good enough for now but I'll change it to match RCW's autofire delay of 2 if it's too fast.

DKS:
I love you, DKS, and it pains me to do this but you're too strong. DKS does more damage than a rangemaster, has AP comparable to an AMR, and great bullet speed. Its damage and AP are toned down but it keeps bullet speed since it's a sniper. It snipes.

Lee-Enfield:
Explorers got scuffed when people swapped them to Lee. The extra damage and faster fire rate should give them a comparable performance to DKS.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Pre-Merge Checklist
<!-- Don't bother filling these in while creating your Pull Request, just click the checkboxes after the Pull Request is opened and you are redirected to the page. -->
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
<!-- Neither the compiler nor workflow checks are perfect at detecting runtimes and errors. It is important to test your code/feature/fix locally. -->



<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
