### PR TITLE
Centurion David and Goliath (readds goliath powerfist to palacent)

### DIFF
--- a/code/game/objects/items/melee/f13powerfist.dm
+++ b/code/game/objects/items/melee/f13powerfist.dm
@@ -63,7 +63,6 @@
 	icon_state = "goliath"
 	item_state = "goliath"
 	force = 25
-	armour_penetration = 0
 	throw_distance = 2
 
 

--- a/code/game/objects/items/melee/f13powerfist.dm
+++ b/code/game/objects/items/melee/f13powerfist.dm
@@ -63,7 +63,7 @@
 	icon_state = "goliath"
 	item_state = "goliath"
 	force = 25
-	throw_distance = 2
+	throw_distance = 3
 
 
 // Ballistic Fist			Keywords: Damage max 42, AP 0.45, Shotgun

--- a/code/game/objects/items/melee/f13powerfist.dm
+++ b/code/game/objects/items/melee/f13powerfist.dm
@@ -63,7 +63,7 @@
 	icon_state = "goliath"
 	item_state = "goliath"
 	force = 25
-	throw_distance = 3
+	throw_distance = 2
 
 
 // Ballistic Fist			Keywords: Damage max 42, AP 0.45, Shotgun

--- a/code/game/objects/items/melee/f13powerfist.dm
+++ b/code/game/objects/items/melee/f13powerfist.dm
@@ -63,6 +63,7 @@
 	icon_state = "goliath"
 	item_state = "goliath"
 	force = 25
+	armour_penetration = 0
 	throw_distance = 2
 
 

--- a/code/modules/jobs/job_types/legion.dm
+++ b/code/modules/jobs/job_types/legion.dm
@@ -258,6 +258,7 @@ Weapons		Lever shotgun, Grease gun, Repeater carbines, Revolvers, simple guns al
 	suit_store = /obj/item/gun/ballistic/automatic/m1919
 	backpack_contents = list(
 		/obj/item/melee/onehanded/machete/spatha = 1,
+		/obj/item/melee/powerfist/f13/goliath = 1,
 		/obj/item/ammo_box/magazine/mm762 = 1,
 		)
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

<!-- NOTE: This format is NOT REQUIRED for things like runtime fixes, code fixes and optimizations. In those instances you should try to give a description of what is being fixed or optimized but are not required to fill out the complete changelog. -->
<!-- Adjusting things like armor or weapon values for balance, while they may be 'fixes' in their own way, are not considered code fixes as described above and require the use of the Pull Request format below.-->


## About The Pull Request
See title.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
I'm not sure why Goliath was removed from Palacent but it'll be hilarious to send troopers and legionnaries flying with a click. Pinball but with people.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Pre-Merge Checklist
<!-- Don't bother filling these in while creating your Pull Request, just click the checkboxes after the Pull Request is opened and you are redirected to the page. -->
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
<!-- Neither the compiler nor workflow checks are perfect at detecting runtimes and errors. It is important to test your code/feature/fix locally. -->

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
