### PR TITLE
Reduced RCW (nerf)

### DIFF
--- a/code/modules/projectiles/projectile/beams.dm
+++ b/code/modules/projectiles/projectile/beams.dm
@@ -490,7 +490,8 @@
 /obj/item/projectile/beam/laser/rcw/hitscan //RCW
 	name = "rapidfire beam"
 	icon_state = "emitter"
-	damage = 25 //ALWAYS does 50, this is a burstfire hitscan weapon that fires in bursts of 2.
+	damage = 16 //ALWAYS does 50, this is a burstfire hitscan weapon that fires in bursts of 2.
+	armour_penetration = 0.02
 	hitscan = TRUE
 	muzzle_type = /obj/effect/projectile/muzzle/laser/emitter
 	tracer_type = /obj/effect/projectile/tracer/laser/emitter


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

<!-- NOTE: This format is NOT REQUIRED for things like runtime fixes, code fixes and optimizations. In those instances you should try to give a description of what is being fixed or optimized but are not required to fill out the complete changelog. -->
<!-- Adjusting things like armor or weapon values for balance, while they may be 'fixes' in their own way, are not considered code fixes as described above and require the use of the Pull Request format below.-->


## About The Pull Request
See title.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
RCW currently fires 25 damage beams at an autofire delay of 2. It's also hitscan. The wasteland barely has laser protection. A squad of Knights with RCWs can roll up on anyone and delete them from existence. Damage is reduced and it gives them some minor AP for chip damage.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Pre-Merge Checklist
<!-- Don't bother filling these in while creating your Pull Request, just click the checkboxes after the Pull Request is opened and you are redirected to the page. -->
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
<!-- Neither the compiler nor workflow checks are perfect at detecting runtimes and errors. It is important to test your code/feature/fix locally. -->

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
