### PR TITLE
blacksmithing rebalance

### DIFF
--- a/code/datums/components/crafting/recipes/recipes_tribal.dm
+++ b/code/datums/components/crafting/recipes/recipes_tribal.dm
@@ -34,7 +34,6 @@
 	result = /obj/item/gun/syringe/blowgun
 	time = 50
 	reqs = list(/obj/item/stack/sheet/mineral/bamboo = 10)
-	always_available = FALSE
 
 /datum/crafting_recipe/tribalwar/bow
 	name = "String Wooden Bow"
@@ -49,7 +48,6 @@
 	name = "Manual Crossbow"
 	result = /obj/item/gun/ballistic/bow/xbow
 	time = 120
-	always_available = FALSE
 	reqs = list(/obj/item/stack/crafting/metalparts = 5,
 				/obj/item/stack/rods = 1,
 				/obj/item/stack/sheet/mineral/wood = 15,

--- a/code/modules/jobs/job_types/legion.dm
+++ b/code/modules/jobs/job_types/legion.dm
@@ -1014,8 +1014,6 @@ commented out pending rework*/
 	H.mind.teach_crafting_recipe(/datum/crafting_recipe/concussion)
 	H.mind.teach_crafting_recipe(/datum/crafting_recipe/strongrocket)
 	H.mind.teach_crafting_recipe(/datum/crafting_recipe/empgrenade)
-	H.mind.teach_crafting_recipe(/datum/crafting_recipe/tribalwar/xbow)
-	H.mind.teach_crafting_recipe(/datum/crafting_recipe/tribalwar/cheaparrow)
 
 
 

--- a/code/modules/smithing/finished_items.dm
+++ b/code/modules/smithing/finished_items.dm
@@ -33,6 +33,7 @@
 /obj/item/melee/smith/twohand
 	item_flags = NEEDS_PERMIT //it's a bigass sword/spear. beepsky is going to give you shit for it.
 	sharpness = SHARP_EDGED
+	attack_speed = CLICK_CD_MELEE * 1.1
 	material_flags = MATERIAL_COLOR | MATERIAL_AFFECT_STATISTICS
 	force = 10
 	wielded_mult = 1.75
@@ -116,7 +117,7 @@
 	icon_state = "halberd"
 	w_class = WEIGHT_CLASS_HUGE
 	overlay_state = "spearhandle"
-	total_mass = TOTAL_MASS_MEDIEVAL_WEAPON * 2// high stam cost on swing
+	attack_speed = CLICK_CD_MELEE * 1.25
 	max_reach = 2
 	slot_flags = ITEM_SLOT_BACK
 	wielded_mult = 1.75
@@ -235,7 +236,7 @@
 	name = "zweihander"
 	icon_state = "zwei"
 	overlay_state = "zweihilt"
-	total_mass = TOTAL_MASS_MEDIEVAL_WEAPON * 5//extremely high stam cost on swing
+	attack_speed = CLICK_CD_MELEE * 1.2
 	wielded_mult = 3.5 //affected more by quality due to its high wielded mult
 
 /obj/item/melee/smith/twohand/katana

--- a/code/modules/smithing/finished_items.dm
+++ b/code/modules/smithing/finished_items.dm
@@ -8,8 +8,9 @@
 	material_flags = MATERIAL_COLOR | MATERIAL_AFFECT_STATISTICS
 	total_mass = TOTAL_MASS_MEDIEVAL_WEAPON //yeah ok
 	slot_flags = ITEM_SLOT_BELT
+	obj_flags = UNIQUE_RENAME
 	w_class = WEIGHT_CLASS_NORMAL
-	force = 6
+	force = 5
 	lefthand_file = 'icons/mob/inhands/weapons/swords_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/weapons/swords_righthand.dmi'
 	var/quality
@@ -32,7 +33,6 @@
 /obj/item/melee/smith/twohand
 	item_flags = NEEDS_PERMIT //it's a bigass sword/spear. beepsky is going to give you shit for it.
 	sharpness = SHARP_EDGED
-	obj_flags = UNIQUE_RENAME
 	material_flags = MATERIAL_COLOR | MATERIAL_AFFECT_STATISTICS
 	force = 10
 	wielded_mult = 1.75
@@ -116,10 +116,10 @@
 	icon_state = "halberd"
 	w_class = WEIGHT_CLASS_HUGE
 	overlay_state = "spearhandle"
+	total_mass = TOTAL_MASS_MEDIEVAL_WEAPON * 2// high stam cost on swing
 	max_reach = 2
 	slot_flags = ITEM_SLOT_BACK
-	obj_flags = UNIQUE_RENAME
-	wielded_mult = 1.8
+	wielded_mult = 1.95
 
 /obj/item/melee/smith/twohand/halberd/ComponentInitialize()
 	. = ..()
@@ -130,9 +130,9 @@
 	name = "javelin"
 	icon_state = "javelin"
 	overlay_state = "longhandle"
-	wielded_mult = 1.5
+	wielded_mult = 1.25
+	armour_penetration = 0.2
 	slot_flags = ITEM_SLOT_BACK
-	obj_flags = UNIQUE_RENAME
 	sharpness = SHARP_POINTY
 
 
@@ -146,8 +146,7 @@
 	overlay_state = "longhandle"
 	max_reach = 2
 	slot_flags = ITEM_SLOT_BACK
-	obj_flags = UNIQUE_RENAME
-	wielded_mult = 1.5
+	wielded_mult = 1.45
 
 /obj/item/melee/smith/twohand/glaive/ComponentInitialize()
 	. = ..()
@@ -158,10 +157,9 @@
 	name = "pike"
 	icon_state = "pike"
 	overlay_state = "longhandle"
-	max_reach = 2 //yeah ok
-	wielded_mult = 1.3
+	max_reach = 3 //yeah ok
+	wielded_mult = 1.25
 	slot_flags = ITEM_SLOT_BACK
-	obj_flags = UNIQUE_RENAME
 	sharpness = SHARP_POINTY
 
 //////////////////////////
@@ -176,7 +174,6 @@
 	var/qualitymod = 0
 
 /obj/item/scythe/smithed //we need to inherit scythecode, but that's about it.
-	obj_flags = UNIQUE_RENAME
 	material_flags = MATERIAL_COLOR | MATERIAL_AFFECT_STATISTICS
 
 
@@ -184,14 +181,14 @@
 	name = "coghead club"
 	icon_state = "coghead"
 	item_flags = NEEDS_PERMIT
-	obj_flags = UNIQUE_RENAME
 	overlay_state = "stick"
+	bare_wound_bonus = 5
+	wound_bonus = 5
 
 /obj/item/melee/smith/shortsword
 	name = "gladius"
-	force = 9
+	force = 4
 	item_flags = NEEDS_PERMIT
-	obj_flags = UNIQUE_RENAME
 	sharpness = SHARP_EDGED
 	icon_state = "gladius"
 	overlay_state = "gladiushilt"
@@ -199,16 +196,14 @@
 /obj/item/melee/smith/shortsword/scimitar
 	name = "scimitar"
 	sharpness = SHARP_EDGED
-	obj_flags = UNIQUE_RENAME
 	icon_state = "scimitar"
 	overlay_state = "scimitarhilt"
 
 /obj/item/melee/smith/wakizashi
 	name = "wakizashi"
 	sharpness = SHARP_EDGED
-	force = 7
+	force = 3
 	item_flags = NEEDS_PERMIT | ITEM_CAN_PARRY
-	obj_flags = UNIQUE_RENAME
 	icon_state = "waki"
 	overlay_state = "wakihilt"
 	block_parry_data = /datum/block_parry_data/waki
@@ -225,33 +220,45 @@
 	parry_efficiency_considered_successful = 80
 	parry_efficiency_perfect = 120
 	parry_failed_stagger_duration = 3 SECONDS
+	parry_efficiency_perfect_override = list(
+		ATTACK_TYPE_PROJECTILE_TEXT = 10,
+	)
 	parry_data = list(PARRY_COUNTERATTACK_MELEE_ATTACK_CHAIN = 1.9)
 
 /obj/item/melee/smith/twohand/broadsword
 	name = "broadsword"
 	icon_state = "broadsword"
 	overlay_state = "broadhilt"
-	obj_flags = UNIQUE_RENAME
 	wielded_mult = 1.8
 
 /obj/item/melee/smith/twohand/zweihander
 	name = "zweihander"
 	icon_state = "zwei"
 	overlay_state = "zweihilt"
-	total_mass = TOTAL_MASS_MEDIEVAL_WEAPON * 2
-	force = 4
-	obj_flags = UNIQUE_RENAME
-	wielded_mult = 2 //affected more by quality. a -1 is 25% less damage, a +1 is 25% more. These bonuses are tripled when wielded.
+	total_mass = TOTAL_MASS_MEDIEVAL_WEAPON * 5//extremely high stam cost on swing
+	wielded_mult = 3.5 //affected more by quality due to its high wielded mult
 
 /obj/item/melee/smith/twohand/katana
 	name = "katana"
 	icon_state = "katana"
 	overlay_state = "katanahilt"
-	force = 7
-	wielded_mult = 2
-	item_flags = ITEM_CAN_PARRY | NEEDS_PERMIT //want to name your katana "DEMON BLADE" or some shit? go ahead, idiot.
-	obj_flags = UNIQUE_RENAME
-	block_parry_data = /datum/block_parry_data/captain_saber //todo
+	wielded_mult = 1.25
+	item_flags = ITEM_CAN_PARRY | NEEDS_PERMIT
+	block_parry_data = /datum/block_parry_data/katana
+
+/datum/block_parry_data/katana
+	parry_time_windup = 0.5
+	parry_time_active = 4
+	parry_time_spindown = 1
+	parry_time_perfect = 0.75
+	parry_time_perfect_leeway = 0.75
+	parry_imperfect_falloff_percent = 30
+	parry_efficiency_perfect = 100
+	parry_failed_stagger_duration = 3 SECONDS
+	parry_failed_clickcd_duration = 2 SECONDS
+	parry_efficiency_perfect_override = list(
+		ATTACK_TYPE_PROJECTILE_TEXT = 10,
+	)
 
 /obj/item/melee/smith/sabre
 	name = "sabre"
@@ -259,27 +266,25 @@
 	sharpness = SHARP_EDGED
 	overlay_state = "sabrehilt"
 	armour_penetration = 0.3
-	force = 9
+	force = 3
 	hitsound = 'sound/weapons/rapierhit.ogg'
 	item_flags = NEEDS_PERMIT | ITEM_CAN_PARRY
-	obj_flags = UNIQUE_RENAME
-	block_parry_data = /datum/block_parry_data/captain_saber //yeah this is fine i guess
+	block_parry_data = /datum/block_parry_data/katana //yeah this is fine i guess
 
 /obj/item/melee/smith/sabre/rapier
 	name = "rapier"
 	icon_state = "rapier"
 	sharpness = SHARP_EDGED
 	overlay_state = "rapierhilt"
-	force = 6 //less force, stronger parry
+	force = 2 //less force, stronger parry
 	sharpness = SHARP_POINTY
 	armour_penetration = 0.6
-	obj_flags = UNIQUE_RENAME
 	block_parry_data = /datum/block_parry_data/smithrapier
 
-/datum/block_parry_data/smithrapier //parry into riposte. i am pretty sure this is going to be nearly fucking impossible to land.
-	parry_stamina_cost = 12 //dont miss
-	parry_time_active = 4
-	parry_time_perfect = 2
+/datum/block_parry_data/smithrapier
+	parry_stamina_cost = 20 //dont miss
+	parry_time_active = 3
+	parry_time_perfect = 1
 	parry_time_perfect_leeway = 2
 	parry_failed_stagger_duration = 3 SECONDS
 	parry_failed_clickcd_duration = 3 SECONDS
@@ -289,6 +294,9 @@
 	parry_efficiency_to_counterattack = 100
 	parry_efficiency_considered_successful = 120
 	parry_efficiency_perfect = 120
+	parry_efficiency_perfect_override = list(
+		ATTACK_TYPE_PROJECTILE_TEXT = 10,
+	)
 	parry_data = list(PARRY_COUNTERATTACK_MELEE_ATTACK_CHAIN = 4)
 
 //unique hammers

--- a/code/modules/smithing/finished_items.dm
+++ b/code/modules/smithing/finished_items.dm
@@ -119,7 +119,7 @@
 	total_mass = TOTAL_MASS_MEDIEVAL_WEAPON * 2// high stam cost on swing
 	max_reach = 2
 	slot_flags = ITEM_SLOT_BACK
-	wielded_mult = 1.95
+	wielded_mult = 1.75
 
 /obj/item/melee/smith/twohand/halberd/ComponentInitialize()
 	. = ..()

--- a/code/modules/smithing/smithed_items.dm
+++ b/code/modules/smithing/smithed_items.dm
@@ -164,8 +164,8 @@
 
 /obj/item/smithing/scytheblade/startfinish()
 	finalitem = new /obj/item/scythe/smithed(src)
-	finalitem.force += quality*2.5
-	//finalitem.armour_penetration += quality*0.0375
+	finalitem.force = quality*4.5 //36 at 8 quality
+
 	..()
 
 /obj/item/smithing/shovelhead
@@ -189,7 +189,7 @@
 
 /obj/item/smithing/cogheadclubhead/startfinish()
 	finalitem = new /obj/item/melee/smith/cogheadclub(src)
-	finalitem.force += quality*3.4
+	finalitem.force += quality*3.5 //33 at 8 quality, 38 for wounding, and 43 for bare wounding
 	..()
 
 /obj/item/smithing/javelinhead
@@ -199,11 +199,11 @@
 
 /obj/item/smithing/javelinhead/startfinish()
 	var/obj/item/melee/smith/twohand/javelin/finalforreal = new /obj/item/melee/smith/twohand/javelin(src)
-	finalforreal.force += quality*2.5
-	//finalforreal.armour_penetration += quality*0.0375
+	finalforreal.force += quality*2 //26 at 8 quality
+
 	finalforreal.wield_force = finalforreal.force*finalforreal.wielded_mult
-	finalforreal.AddComponent(/datum/component/two_handed, force_unwielded=finalforreal.force, force_wielded=finalforreal.wield_force, icon_wielded="[icon_state]")
-	finalforreal.throwforce = finalforreal.force*2
+	finalforreal.AddComponent(/datum/component/two_handed, force_unwielded=finalforreal.force, force_wielded=finalforreal.wield_force, icon_wielded="[icon_state]") //32.5 at 8 quality, wielded
+	finalforreal.throwforce = finalforreal.force*2 //52 at 8 quality, but no embed
 	finalitem = finalforreal
 	..()
 
@@ -214,10 +214,10 @@
 
 /obj/item/smithing/pikehead/startfinish()
 	var/obj/item/melee/smith/twohand/pike/finalforreal = new /obj/item/melee/smith/twohand/pike(src)
-	finalforreal.force += quality*2.5
-	//finalforreal.armour_penetration += quality*0.0375
+	finalforreal.force += quality*2//26 at 8 quality
+
 	finalforreal.wield_force = finalforreal.force*finalforreal.wielded_mult
-	finalforreal.AddComponent(/datum/component/two_handed, force_unwielded=finalforreal.force, force_wielded=finalforreal.wield_force, icon_wielded="[icon_state]")
+	finalforreal.AddComponent(/datum/component/two_handed, force_unwielded=finalforreal.force, force_wielded=finalforreal.wield_force, icon_wielded="[icon_state]")//32.5 at 8 quality, wielded
 	finalforreal.throwforce = finalforreal.force/10 //its a pike not a javelin
 	finalitem = finalforreal
 	..()
@@ -269,8 +269,8 @@
 
 /obj/item/smithing/shortswordblade/startfinish()
 	finalitem = new /obj/item/melee/smith/shortsword(src)
-	finalitem.force += quality*2.5
-	//finalitem.armour_penetration += quality*0.0375
+	finalitem.force += quality*4 //36 at 8 quality
+
 	..()
 
 /obj/item/smithing/scimitarblade
@@ -281,8 +281,8 @@
 
 /obj/item/smithing/scimitarblade/startfinish()
 	finalitem = new /obj/item/melee/smith/shortsword/scimitar(src)
-	finalitem.force += quality*2.5
-	//finalitem.armour_penetration += quality*0.0025
+	finalitem.force += quality*4 //36 at 8 quality
+
 	..()
 
 /obj/item/smithing/wakiblade
@@ -293,8 +293,8 @@
 
 /obj/item/smithing/wakiblade/startfinish()
 	finalitem = new /obj/item/melee/smith/wakizashi(src)
-	finalitem.force += quality*2.5
-	//finalitem.armour_penetration += quality*0.0375
+	finalitem.force += quality*3.5 //31 at 8 quality
+
 	..()
 
 /obj/item/smithing/sabreblade
@@ -305,8 +305,8 @@
 
 /obj/item/smithing/sabreblade/startfinish()
 	finalitem = new /obj/item/melee/smith/sabre(src)
-	finalitem.force += quality*2.5
-	//finalitem.armour_penetration += quality*0.0375
+	finalitem.force += quality*3.5 //31 at 8 quality
+
 	..()
 
 /obj/item/smithing/rapierblade
@@ -317,8 +317,8 @@
 
 /obj/item/smithing/rapierblade/startfinish()
 	finalitem = new /obj/item/melee/smith/sabre/rapier(src)
-	finalitem.force += quality*2.5
-	//finalitem.armour_penetration += quality*0.0375
+	finalitem.force += quality*3 //26 at 8 quality, but 0.6 ap
+
 	..()
 
 /obj/item/smithing/knifeblade
@@ -328,9 +328,8 @@
 	icon_state = "dagger"
 
 /obj/item/smithing/knifeblade/startfinish()
-	finalitem = new /obj/item/kitchen/knife(src)
-	finalitem.force = 4 + quality/2
-	finalitem.armour_penetration += quality*0.0375
+	finalitem = new /obj/item/melee/onehanded/knife/survival(src)
+	finalitem.force = 3 + quality*3.5//31 at 8 quality
 	finalitem.icon = 'icons/obj/smith.dmi'
 	finalitem.icon_state = "dagger"
 	finalitem.name = "dagger"
@@ -351,10 +350,9 @@
 
 /obj/item/smithing/broadblade/startfinish()
 	var/obj/item/melee/smith/twohand/broadsword/finalforreal = new /obj/item/melee/smith/twohand/broadsword(src)
-	finalforreal.force += quality*2.5
-	//finalforreal.armour_penetration += quality*0.0375
+	finalforreal.force += quality*2.5//30 force onehanded 8 quality
 	finalforreal.wield_force = finalforreal.force*finalforreal.wielded_mult
-	finalforreal.AddComponent(/datum/component/two_handed, force_unwielded=finalforreal.force, force_wielded=finalforreal.wield_force, icon_wielded="[icon_state]")
+	finalforreal.AddComponent(/datum/component/two_handed, force_unwielded=finalforreal.force, force_wielded=finalforreal.wield_force, icon_wielded="[icon_state]")//54 force twohanded at 8 quality
 	finalitem = finalforreal
 	..()
 
@@ -366,10 +364,9 @@
 
 /obj/item/smithing/zweiblade/startfinish()
 	var/obj/item/melee/smith/twohand/zweihander/finalforreal = new /obj/item/melee/smith/twohand/zweihander(src)
-	finalforreal.force += quality*2.5
-	//finalforreal.armour_penetration += quality*0.0375
+	finalforreal.force += quality //18 force onehanded 8 quality
 	finalforreal.wield_force = finalforreal.force*finalforreal.wielded_mult
-	finalforreal.AddComponent(/datum/component/two_handed, force_unwielded=finalforreal.force, force_wielded=finalforreal.wield_force, icon_wielded="[icon_state]")
+	finalforreal.AddComponent(/datum/component/two_handed, force_unwielded=finalforreal.force, force_wielded=finalforreal.wield_force, icon_wielded="[icon_state]")//63 force wielded at 8 quality
 	finalitem = finalforreal
 	..()
 
@@ -380,11 +377,10 @@
 
 /obj/item/smithing/halberdhead/startfinish()
 	var/obj/item/melee/smith/twohand/halberd/finalforreal = new /obj/item/melee/smith/twohand/halberd(src)
-	finalforreal.force += quality*2.5
-	//finalforreal.armour_penetration += quality*0.025
+	finalforreal.force += quality*2 //26 force onehanded, which is impossible
 	finalforreal.wield_force = finalforreal.force*finalforreal.wielded_mult
 	finalforreal.throwforce = finalforreal.force/3
-	finalforreal.AddComponent(/datum/component/two_handed, force_unwielded=finalforreal.force, force_wielded=finalforreal.wield_force, icon_wielded="[icon_state]")
+	finalforreal.AddComponent(/datum/component/two_handed, force_unwielded=finalforreal.force, force_wielded=finalforreal.wield_force, icon_wielded="[icon_state]") //50.7 force twohanded
 	finalitem = finalforreal
 	..()
 
@@ -395,11 +391,10 @@
 
 /obj/item/smithing/glaivehead/startfinish()
 	var/obj/item/melee/smith/twohand/glaive/finalforreal = new /obj/item/melee/smith/twohand/glaive(src)
-	finalforreal.force += quality*2.5
-	//finalforreal.armour_penetration += quality*0.0025
+	finalforreal.force += quality*2
 	finalforreal.wield_force = finalforreal.force*finalforreal.wielded_mult
 	finalforreal.throwforce = finalforreal.force
-	finalforreal.AddComponent(/datum/component/two_handed, force_unwielded=finalforreal.force, force_wielded=finalforreal.wield_force, icon_wielded="[icon_state]")
+	finalforreal.AddComponent(/datum/component/two_handed, force_unwielded=finalforreal.force, force_wielded=finalforreal.wield_force, icon_wielded="[icon_state]")//37.7 force wielded at 8 quality
 	finalitem = finalforreal
 	..()
 
@@ -412,10 +407,9 @@
 
 /obj/item/smithing/katanablade/startfinish()
 	var/obj/item/melee/smith/twohand/katana/finalforreal = new /obj/item/melee/smith/twohand/katana(src)
-	finalforreal.force += quality*2.5
-	//finalforreal.armour_penetration += quality*0.0375
+	finalforreal.force += quality*2.5 //30 force onehanded at 8 quality
 	finalforreal.wield_force = finalforreal.force*finalforreal.wielded_mult
-	finalforreal.AddComponent(/datum/component/two_handed, force_unwielded=finalforreal.force, force_wielded=finalforreal.wield_force, icon_wielded="[icon_state]")
+	finalforreal.AddComponent(/datum/component/two_handed, force_unwielded=finalforreal.force, force_wielded=finalforreal.wield_force, icon_wielded="[icon_state]") //37.5 force twohanded. low for a 2h, but it gets parry to make up for it
 	finalitem = finalforreal
 	..()
 


### PR DESCRIPTION
who the fuck decided 2.5*quality was a good idea i will kill you with my 60 force katana

all smith weapons now parry projectiles at 10% effectiveness- i.e, you can only ignore 10% of the bullet's damage

at 8 quality:
most normal-size onehands are either forgedmachete tier (36) or trenchknife tier (31) with special effects (AP, parry, etc)
rapier is 26 force and 0.6 ap, parry has been made harder
coghead is 33, but gets 5 bwb and 5 wb, making it crunchy
twohands:
javelin is 26 onehand, 32.5 twohand, 52 thrown and gets 0.2 ap
pike is 26 onehand, 32.5 twohand, 2.6 thrown and gets +1 range
glaive is 26 onehanded, 37.7 twohand, 26 thrown. pretty generic spear
halberd is 26 onehanded (iirelevant), 45.5 twohanded and costs significantly more stamina to swing. 

katana is no longer 60(!!) force wielded. it's 26/37.5 1h/2h
broadsword is now 30/54
zweihander is now 18/63(!), but costs like 20-25 stam to swing and is still only one range with zero defensive options

pickaxes have been untouched




## Changelog


:cl:
balance: smithing balance pass
balance: manual crossbow/blowgun now available to everyone (this should've been in a previous tribal pr but i forgot)
/:cl:


