### PR TITLE
powerfist refactor

### DIFF
--- a/code/_globalvars/lists/maintenance_loot.dm
+++ b/code/_globalvars/lists/maintenance_loot.dm
@@ -483,13 +483,13 @@ GLOBAL_LIST_INIT(loot_t5_melee, list(
 	/obj/item/twohanded/chainsaw,
 	/obj/item/melee/transforming/energy/axe/protonaxe,
 	/obj/item/melee/powered/ripper,
-	/obj/item/melee/powerfist/f13,
+	/obj/item/melee/unarmed/powerfist,
 	/obj/item/twohanded/sledgehammer/rockethammer,
 	/obj/item/gun/ballistic/revolver/ballisticfist,
 	/obj/item/twohanded/sledgehammer/supersledge,
 	/obj/item/shishkebabpack,
 	/obj/item/melee/unarmed/deathclawgauntlet,
-	/obj/item/melee/powerfist/f13/moleminer
+	/obj/item/melee/unarmed/powerfist/moleminer
 ))
 
 GLOBAL_LIST_INIT(loot_t1_range, list(

--- a/code/game/objects/effects/spawners/f13lootdrop.dm
+++ b/code/game/objects/effects/spawners/f13lootdrop.dm
@@ -700,13 +700,13 @@ obj/effect/spawner/lootdrop/f13/medical/rnd/good
 				/obj/item/twohanded/chainsaw,
 				/obj/item/twohanded/sledgehammer/rockethammer,
 				/obj/item/melee/powered/ripper,
-				/obj/item/melee/powerfist/f13,
+				/obj/item/melee/unarmed/powerfist,
 				/obj/item/melee/transforming/energy/axe/protonaxe,
 				/obj/item/gun/ballistic/revolver/ballisticfist,
 				/obj/item/twohanded/sledgehammer/supersledge,
 				/obj/item/shishkebabpack,
 				/obj/item/melee/unarmed/deathclawgauntlet,
-				/obj/item/melee/powerfist/f13/moleminer
+				/obj/item/melee/unarmed/powerfist/moleminer
 				)
 
 /obj/effect/spawner/lootdrop/f13/weapon/melee/random

--- a/code/game/objects/effects/spawners/themed_loot_tables.dm
+++ b/code/game/objects/effects/spawners/themed_loot_tables.dm
@@ -320,7 +320,7 @@
 		/obj/item/gun/energy/laser/plasma/glock = 2,
 		/obj/item/gun/energy/laser/plasma = 2,
 		/obj/item/gun/energy/laser/plasma/scatter =1,
-		/obj/item/melee/powerfist/f13/moleminer = 10,
+		/obj/item/melee/unarmed/powerfist/moleminer = 10,
 		/obj/item/melee/transforming/energy/axe/protonaxe = 10,
 		/obj/item/gun/ballistic/revolver/ballisticfist = 5,
 		)

--- a/code/game/objects/items/melee/f13powerfist.dm
+++ b/code/game/objects/items/melee/f13powerfist.dm
@@ -3,7 +3,7 @@
 /////////////////		-Uses power (gas currently) for knockback. Heavy AP, specialized for attacking heavy armor
 
 // Power Fist			Throws targets. Max damage 44. Full AP.
-/obj/item/melee/powerfist/f13
+/obj/item/melee/unarmed/powerfist
 	name = "power fist"
 	desc = "A metal gauntlet with a piston-powered ram on top for that extra 'oomph' in your punch."
 	icon_state = "powerfist"
@@ -15,46 +15,39 @@
 	force = 22
 	throwforce = 10
 	throw_range = 3
+	armour_penetration = 1
 	w_class = WEIGHT_CLASS_NORMAL
-	slot_flags = ITEM_SLOT_BELT | ITEM_SLOT_GLOVES
 	var/transfer_prints = TRUE //prevents runtimes with forensics when held in glove slot
-	var/throw_distance = 1
+	var/throw_distance = 1 //multipled by power to give actual throw dist
+	var/power = 1
+	var/knockback_anchored = FALSE
 	attack_speed = CLICK_CD_MELEE
 
-/obj/item/melee/powerfist/f13/attackby(obj/item/W, mob/user, params)
+/obj/item/melee/unarmed/powerfist/ComponentInitialize()
+	. = ..()
+	AddComponent(/datum/component/knockback, throw_distance, FALSE, knockback_anchored)
+
+
+/obj/item/melee/unarmed/powerfist/attackby(obj/item/W, mob/user, params)
+	if(!power)
+		return
 	if(istype(W, /obj/item/wrench))
-		switch(fisto_setting)
+		switch(power)
 			if(1)
-				fisto_setting = 2
+				power = 2
 			if(2)
-				fisto_setting = 1
+				power = 1
+		if(GetComponent(/datum/component/knockback))
+			var/datum/component/knockback/KB = GetComponent(/datum/component/knockback)
+			KB.throw_distance = initial(throw_distance) * power
 		W.play_tool_sound(src)
-		to_chat(user, "<span class='notice'>You tweak \the [src]'s piston valve to [fisto_setting].</span>")
-		attack_speed = CLICK_CD_MELEE * fisto_setting
+		to_chat(user, "<span class='notice'>You tweak \the [src]'s piston valve to [power].</span>")
+		force = initial(force) * power
+		attack_speed = CLICK_CD_MELEE * power
 
-/obj/item/melee/powerfist/f13/updateTank(obj/item/tank/internals/thetank, removing = 0, mob/living/carbon/human/user)
-	return
-
-/obj/item/melee/powerfist/f13/attack(mob/living/target, mob/living/user, attackchain_flags = NONE)
-	if(HAS_TRAIT(user, TRAIT_PACIFISM))
-		to_chat(user, "<span class='warning'>You don't want to harm other living beings!</span>")
-		return FALSE
-	var/turf/T = get_turf(src)
-	if(!T)
-		return FALSE
-	var/totalitemdamage = target.pre_attacked_by(src, user)
-	target.apply_damage(totalitemdamage * fisto_setting, BRUTE, wound_bonus = -25*fisto_setting**2)
-	target.visible_message("<span class='danger'>[user]'s powerfist lets out a loud hiss as [user.p_they()] punch[user.p_es()] [target.name]!</span>", \
-		"<span class='userdanger'>You cry out in pain as [user]'s punch flings you backwards!</span>")
-	new /obj/effect/temp_visual/kinetic_blast(target.loc)
-	playsound(loc, 'sound/weapons/resonator_blast.ogg', 50, 1)
-	playsound(loc, 'sound/weapons/genhit2.ogg', 50, 1)
-	var/atom/throw_target = get_edge_target_turf(target, get_dir(src, get_step_away(target, src)))
-	target.throw_at(throw_target, 2 * throw_distance, 0.5 + (throw_distance / 2))
-	log_combat(user, target, "power fisted", src)
 
 // Goliath				Throws targets far. Max damage 50.
-/obj/item/melee/powerfist/f13/goliath
+/obj/item/melee/unarmed/powerfist/goliath
 	name = "Goliath"
 	desc = "A massive, experimental metal gauntlet captured by the Legion. The piston-powered ram on top is designed to throw targets very, very far."
 	icon = 'icons/fallout/objects/melee/melee.dmi'
@@ -86,8 +79,8 @@
 	var/transfer_prints = TRUE //prevents runtimes with forensics when held in glove slot
 
 
-// Mole Miner				
-/obj/item/melee/powerfist/f13/moleminer
+// Mole Miner
+/obj/item/melee/unarmed/powerfist/moleminer
 	name = "mole miner gauntlet"
 	desc = "A hand-held mining and cutting implement, repurposed into a deadly melee weapon.  Its name origins are a mystery..."
 	icon_state = "mole_miner_g"
@@ -95,9 +88,7 @@
 	lefthand_file = 'icons/mob/inhands/weapons/melee_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/weapons/melee_righthand.dmi'
 	flags_1 = CONDUCT_1
-	force = 15
-	throwforce = 10
-	throw_range = 7
+	force = 20
 	attack_verb = list("slashed", "sliced", "torn", "ripped", "diced", "cut")
 	hitsound = 'sound/weapons/bladeslice.ogg'
 	tool_behaviour = TOOL_MINING
@@ -105,8 +96,6 @@
 	toolspeed = 0.4
 	sharpness = SHARP_EDGED
 	w_class = WEIGHT_CLASS_NORMAL
-	slot_flags = ITEM_SLOT_BELT | ITEM_SLOT_GLOVES
-	armor = list("melee" = 0, "bullet" = 0, "laser" = 0, "energy" = 0, "bomb" = 0, "bio" = 0, "rad" = 0, "fire" = 0, "acid" = 0)
 
 
 /////////////////////

--- a/code/game/objects/items/melee/f13powerfist.dm
+++ b/code/game/objects/items/melee/f13powerfist.dm
@@ -27,7 +27,6 @@
 	. = ..()
 	AddComponent(/datum/component/knockback, throw_distance, FALSE, knockback_anchored)
 
-
 /obj/item/melee/unarmed/powerfist/attackby(obj/item/W, mob/user, params)
 	if(!power)
 		return

--- a/code/game/objects/items/melee/f13powerfist.dm
+++ b/code/game/objects/items/melee/f13powerfist.dm
@@ -2,7 +2,7 @@
 // POWER FISTS //
 /////////////////		-Uses power (gas currently) for knockback. Heavy AP, specialized for attacking heavy armor
 
-// Power Fist			Throws targets. Max damage 44. Full AP.
+// Power Fist			Throws targets. Max damage 44. 50% ap
 /obj/item/melee/unarmed/powerfist
 	name = "power fist"
 	desc = "A metal gauntlet with a piston-powered ram on top for that extra 'oomph' in your punch."
@@ -15,7 +15,7 @@
 	force = 22
 	throwforce = 10
 	throw_range = 3
-	armour_penetration = 1
+	armour_penetration = 0.5
 	w_class = WEIGHT_CLASS_NORMAL
 	var/transfer_prints = TRUE //prevents runtimes with forensics when held in glove slot
 	var/throw_distance = 1 //multipled by power to give actual throw dist
@@ -58,7 +58,7 @@
 	throw_distance = 3
 
 
-// Ballistic Fist			Keywords: Damage max 42, AP 0.45, Shotgun
+// Ballistic Fist			Keywords: 30 damage, AP 0.45, Shotgun
 /obj/item/gun/ballistic/revolver/ballisticfist
 	name = "ballistic fist"
 	desc = "This powerfist has been modified to have two shotgun barrels welded to it, with the trigger integrated into the knuckle guard. For those times when you want to punch someone and shoot them in the face at the same time."

--- a/code/game/objects/items/melee/f13twohanded.dm
+++ b/code/game/objects/items/melee/f13twohanded.dm
@@ -601,7 +601,6 @@ obj/item/twohanded/sledgehammer/supersledge/afterattack(atom/A, mob/living/user,
 	. = ..()
 	AddComponent(/datum/component/two_handed, force_unwielded = 25, force_wielded = 45, icon_wielded="[icon_prefix]2")
 
-
 // Shaman staff				Keywords: Damage 15/30, Big stamina damage buff
 /obj/item/twohanded/sledgehammer/shamanstaff
 	name = "shaman staff"

--- a/code/modules/jobs/job_types/bos.dm
+++ b/code/modules/jobs/job_types/bos.dm
@@ -151,7 +151,7 @@ Head Paladin
 	neck = 			/obj/item/storage/belt/holster
 	backpack_contents = list(
 		/obj/item/melee/onehanded/knife/hunting = 1,
-		/obj/item/melee/powerfist/f13 = 1,
+		/obj/item/melee/unarmed/powerfist = 1,
 		/obj/item/gun/ballistic/automatic/pistol/n99/crusader = 1,
 		/obj/item/ammo_box/magazine/m10mm_adv/simple = 2,
 		/obj/item/reagent_containers/hypospray/medipen/stimpak = 3,
@@ -419,7 +419,7 @@ Star Paladin
 	backpack_contents = list(
 		/obj/item/melee/onehanded/knife/hunting = 1,
 		/obj/item/reagent_containers/hypospray/medipen/stimpak = 2,
-		/obj/item/melee/powerfist/f13 = 1,
+		/obj/item/melee/unarmed/powerfist = 1,
 		/obj/item/tank/internals/oxygen = 1,
 	)
 

--- a/code/modules/jobs/job_types/legion.dm
+++ b/code/modules/jobs/job_types/legion.dm
@@ -136,7 +136,7 @@ Weapons		Lever shotgun, Grease gun, Repeater carbines, Revolvers, simple guns al
 	suit_store = /obj/item/gun/ballistic/automatic/pistol/pistol14
 	r_pocket = /obj/item/storage/bag/money/small/legion
 	l_pocket = /obj/item/flashlight/lantern
-	r_hand = /obj/item/melee/powerfist/f13/goliath
+	r_hand = /obj/item/melee/unarmed/powerfist/goliath
 	l_hand = /obj/item/tank/internals/oxygen
 	backpack = null
 	satchel = null
@@ -258,7 +258,7 @@ Weapons		Lever shotgun, Grease gun, Repeater carbines, Revolvers, simple guns al
 	suit_store = /obj/item/gun/ballistic/automatic/m1919
 	backpack_contents = list(
 		/obj/item/melee/onehanded/machete/spatha = 1,
-		/obj/item/melee/powerfist/f13/goliath = 1,
+		/obj/item/melee/unarmed/powerfist/goliath = 1,
 		/obj/item/ammo_box/magazine/mm762 = 1,
 		)
 


### PR DESCRIPTION

## Why It's Good For The Game

powerfists inherited from useless (ss13 pfist) code instead of useful code (f13 unarmed fistweapon)

powerfist 100% ap > 50% because 44 100%ap damage is a little much regardless of circumstance

moleminer damage 15>20 because holy shit it was useless

## Pre-Merge Checklist
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.


## Changelog

:cl:
balance: powerfist ap 100%>50%
refactor: powerfist
/:cl:

