### PR TITLE
G11 HP loadout/WT550 SP loadout

### DIFF
--- a/code/game/objects/items/miscellaneous.dm
+++ b/code/game/objects/items/miscellaneous.dm
@@ -292,3 +292,14 @@
 	".357 Single Action Revolver" = /obj/item/gun/ballistic/revolver/colt357,
 	"5.56mm Varmint Rifle" = /obj/item/gun/ballistic/automatic/varmint
 	)
+
+/obj/item/choice_beacon/box/g11ammo
+	name = "choice box (tactical ammunition)"
+	desc = "Contains 50 rounds of your preferred tactical 4.73mm ammunition."
+	var/static/list/ammolist = list("4.73mm flat-nose bullets" = /obj/item/ammo_box/m473/dumdum,
+		"4.73mm incendiary bullets" = /obj/item/ammo_box/m473/incendiary,
+		"4.73mm electro-static discharge bullets" = /obj/item/ammo_box/m473/shock,
+		"4.73mm high-velocity bullets" = /obj/item/ammo_box/m473/hv)
+
+/obj/item/choice_beacon/box/g11ammo/generate_display_names()
+	return ammolist

--- a/code/modules/jobs/job_types/bos.dm
+++ b/code/modules/jobs/job_types/bos.dm
@@ -111,7 +111,8 @@ Head Paladin
 	/datum/outfit/loadout/sentvet, //xl70e3
 	/datum/outfit/loadout/sentheavy, //Gauss + Glock
 	/datum/outfit/loadout/sentgat, // Gatling
-	/datum/outfit/loadout/sentmini // Minigun
+	/datum/outfit/loadout/sentmini, // Minigun
+	/datum/outfit/loadout/senttactical //G11, ammo choice box
 	)
 
 	outfit = /datum/outfit/job/bos/f13sentinel
@@ -192,6 +193,15 @@ Head Paladin
 		/obj/item/minigunpackbal5mm=1,
 		/obj/item/gun/energy/laser/pistol=1,
 		/obj/item/stock_parts/cell/ammo/ec=2,
+	)
+
+/datum/outfit/loadout/senttactical
+	name = "Tactical Head Paladin"
+	backpack_contents = list(
+		/obj/item/gun/ballistic/automatic/g11 = 1,
+		/obj/item/ammo_box/magazine/m473 = 2,
+		/obj/item/ammo_box/magazine/m473/empty = 1,
+		/obj/item/choice_beacon/box/g11ammo = 1,
 	)
 
 
@@ -374,7 +384,8 @@ Star Paladin
 	loadout_options = list(
 		/datum/outfit/loadout/spaladina, //R91 Assault Rifle
 		/datum/outfit/loadout/spaladinb, //AER12
-		/datum/outfit/loadout/spaladinc  //Minigun
+		/datum/outfit/loadout/spaladinc,  //Minigun
+		/datum/outfit/loadout/spaladintactical //WT-550, ammo choice box
 		)
 
 	outfit = /datum/outfit/job/bos/f13seniorpaladin
@@ -448,6 +459,15 @@ Star Paladin
 		/obj/item/ammo_box/magazine/m2mm = 3,
 		/obj/item/gun/energy/laser/pistol=1,
 		/obj/item/stock_parts/cell/ammo/ec=2,
+	)
+
+/datum/outfit/loadout/spaladintactical
+	name = "Tactical Senior Paladin"
+	backpack_contents = list(
+		/obj/item/gun/ballistic/automatic/wt550 = 1,
+		/obj/item/ammo_box/magazine/m473/small = 3,
+		/obj/item/ammo_box/magazine/m473/small/empty = 3,
+		/obj/item/choice_beacon/box/g11ammo = 1,
 	)
 
 /*
@@ -720,7 +740,7 @@ Scribe
 		)
 
 /*
-Senior 
+Senior
 */
 
 /datum/job/bos/f13seniorknight

--- a/code/modules/projectiles/ammunition/caseless/ballistic.dm
+++ b/code/modules/projectiles/ammunition/caseless/ballistic.dm
@@ -12,11 +12,11 @@
 /obj/item/ammo_casing/caseless/g11/incendiary
 	name = "4.73mm tracer cartridge"
 	projectile_type  = /obj/item/projectile/bullet/a473/incendiary
-	
+
 /obj/item/ammo_casing/caseless/g11/uraniumtipped
 	name = "4.73mm U-235 cartridge"
 	projectile_type  = /obj/item/projectile/bullet/a473/uraniumtipped
-	
+
 /obj/item/ammo_casing/caseless/g11/dumdum
 	name = "4.73mm flat-nose cartridge"
 	projectile_type  = /obj/item/projectile/bullet/a473/dumdum
@@ -27,3 +27,11 @@
 	caliber = "473mm"
 	icon_state = "762-casing"
 	projectile_type = /obj/item/projectile/bullet/a473/explosive
+
+/obj/item/ammo_casing/caseless/g11/shock
+	name = "4.73mm electro-static discharge cartridge"
+	projectile_type  = /obj/item/projectile/bullet/a473/shock
+
+/obj/item/ammo_casing/caseless/g11/hv
+	name = "4.73mm highvelocity cartridge"
+	projectile_type  = /obj/item/projectile/bullet/a473/hv

--- a/code/modules/projectiles/boxes_magazines/ammo_boxes.dm
+++ b/code/modules/projectiles/boxes_magazines/ammo_boxes.dm
@@ -491,6 +491,35 @@
 	ammo_type = /obj/item/ammo_casing/caseless/g11
 	max_ammo = 50
 
+/obj/item/ammo_box/m473/rubber
+	name = "ammo box (4.73mm less-than-lethal)"
+	ammo_type = /obj/item/ammo_casing/caseless/g11/rubber
+
+/obj/item/ammo_box/m473/incendiary
+	name = "ammo box (4.73mm incendiary)"
+	ammo_type = /obj/item/ammo_casing/caseless/g11/incendiary
+
+/obj/item/ammo_box/m473/uraniumtipped
+	name = "ammo box (4.73mm uranium-tipped)"
+	ammo_type = /obj/item/ammo_casing/caseless/g11/uraniumtipped
+
+/obj/item/ammo_box/m473/dumdum
+	name = "ammo box (4.73mm flat-nose)"
+	ammo_type = /obj/item/ammo_casing/caseless/g11/dumdum
+
+/obj/item/ammo_box/m473/explosive
+	name = "ammo box (4.73mm explosive)"
+	desc = "Explosive caseless rounds. Very safe."
+	ammo_type = /obj/item/ammo_casing/caseless/g11/explosive
+
+/obj/item/ammo_box/m473/shock
+	name = "ammo box (4.73mm ESD)"
+	ammo_type = /obj/item/ammo_casing/caseless/g11/shock
+
+/obj/item/ammo_box/m473/hv
+	name = "ammo box (4.73mm high-velocity)"
+	ammo_type = /obj/item/ammo_casing/caseless/g11/hv
+
 /obj/item/ammo_box/lasmusket
 	name = "Battery box (Laser musket)"
 	icon = 'icons/fallout/objects/guns/ammo.dmi'

--- a/code/modules/projectiles/boxes_magazines/external/rifle.dm
+++ b/code/modules/projectiles/boxes_magazines/external/rifle.dm
@@ -148,6 +148,14 @@
 	max_ammo = 50
 	multiple_sprites = 2
 
+/obj/item/ammo_box/magazine/m473
+	name = "g11 magazine (4.73mm)"
+	icon_state = "473mm"
+	caliber = "473mm"
+	ammo_type = /obj/item/ammo_casing/caseless/g11
+	max_ammo = 50
+	multiple_sprites = 2
+
 /obj/item/ammo_box/magazine/m473/explosive
 	name = "g11 magazine (4.73mm explosive)"
 	icon_state = "473mm"
@@ -163,6 +171,9 @@
 	name = "4.7mm carbine magazine"
 	icon_state = "473small"
 	max_ammo = 20
+
+/obj/item/ammo_box/magazine/m473/small/empty
+	start_empty = 1
 
 /obj/item/ammo_box/magazine/m2mm
 	name = "2mm electromagnetic magazine"

--- a/code/modules/projectiles/guns/ballistic/automatic.dm
+++ b/code/modules/projectiles/guns/ballistic/automatic.dm
@@ -1296,17 +1296,26 @@
 	var/mob/living/carbon/human/user = usr
 	switch(select)
 		if(0)
-			select += 1
-			burst_size = 3
+			select += 1]
+			if(burst_improvement)
+				burst_size = 5
+			else
+				burst_size = 3
 			automatic = FALSE
-			burst_spread = 7.5
+			if(recoil_decrease)
+				burst_spread = 5.5
+			else
+				burst_spread = 7.5
 			recoil = 0.25
 			to_chat(user, "<span class='notice'>You switch to burst fire.</span>")
 		if(1)
 			select += 1
 			burst_size = 1
 			automatic = TRUE
-			spread = 12.5
+			if(recoil_decrease)
+				burst_spread = 8.5
+			else
+				burst_spread = 12.5
 			recoil = 0.5
 			to_chat(user, "<span class='notice'>You switch to full-auto.</span>")
 		if(2)

--- a/code/modules/projectiles/guns/ballistic/automatic.dm
+++ b/code/modules/projectiles/guns/ballistic/automatic.dm
@@ -1275,7 +1275,7 @@
 	is_automatic = TRUE
 	automatic = FALSE
 	extra_penetration = 0.1
-	autofire_shot_delay = 2
+	autofire_shot_delay = 1.75
 	burst_shot_delay = 0.5
 	can_attachments = TRUE
 	semi_auto = TRUE

--- a/code/modules/projectiles/guns/ballistic/automatic.dm
+++ b/code/modules/projectiles/guns/ballistic/automatic.dm
@@ -228,7 +228,7 @@
 	mag_type = /obj/item/ammo_box/magazine/greasegun
 	spread = 6
 	extra_damage = 20
-	burst_shot_delay = 3.25 
+	burst_shot_delay = 3.25
 	is_automatic = TRUE
 	automatic = 1
 	autofire_shot_delay = 3.25 //barely faster than semi-auto
@@ -605,23 +605,25 @@
 	icon_state = "[initial(icon_state)][magazine ? "-[magazine.max_ammo]" : ""][chambered ? "" : "-e"][stock ? "" : "-f"]"
 
 
-//WT-550								4.7mm, 20 round magazine, low damage/low AP
+//WT-550								4.7mm, 20 round magazine
 /obj/item/gun/ballistic/automatic/wt550
-	name = "Prototype Carbine"
-	desc = "A carbine made by vault-tec, chambered in a curious caseless round and designed to fire a multitude of bullets. It has 'WT-550' on the side. This one looks like it was repaired by the Oasis citizenry."
+	name = "WT-550"
+	desc = "A compact PDW derived from the G11, firing the same 4.73mm rounds."
 	item_state = "wt550"
 	mag_type = /obj/item/ammo_box/magazine/m473/small
-	semi_auto = TRUE
 	burst_size = 1
-	extra_damage = 15
+	is_automatic = TRUE
+	automatic = TRUE
+	extra_damage = 20
+	autofire_shot_delay = 2
 	extra_penetration = 0.2
 	w_class = WEIGHT_CLASS_NORMAL
 	weapon_weight = WEAPON_MEDIUM
-	spread = 0 //low-recoil + forward grip
-	fire_delay = 3
-
-
-
+	spread = 0
+	fire_delay = 1
+	can_bayonet = TRUE
+	knife_x_offset = 25
+	knife_y_offset = 12
 
 ////////////////////
 //SEMI-AUTO RIFLES//
@@ -1213,8 +1215,8 @@
 	extra_damage = 22
 	spread = 9 //longer barrel
 	can_scope = TRUE
-	
-/obj/item/gun/ballistic/automatic/assault_carbine/worn	
+
+/obj/item/gun/ballistic/automatic/assault_carbine/worn
 	name = "worn assault carbine"
 	desc = "The U.S. army carbine version of the R91, made by Colt and issued to special forces. This one is beat-up and falling apart."
 	icon_state = "assault_carbine"
@@ -1263,28 +1265,59 @@
 //H&K G11				Keywords: 4.73mm, Automatic, 50 round magazine
 /obj/item/gun/ballistic/automatic/g11
 	name = "g11"
-	desc = "This experimental german gun fires a caseless cartridge consisting of a block of propellant with a bullet buried inside. The weight and space savings allows for a very high magazine capacity. Chambered in 4.73mm."
+	desc = "This experimental gun fires a caseless cartridge consisting of a block of propellant with a bullet buried inside. The weight and space savings allows for a very high magazine capacity. Chambered in 4.73mm."
 	icon_state = "g11"
 	item_state = "g11"
 	mag_type = /obj/item/ammo_box/magazine/m473
-	extra_damage = 23
-	fire_delay = 2.5
+	burst_size = 1
+	extra_damage = 20
+	fire_delay = 2
 	is_automatic = TRUE
-	automatic = 1
-	autofire_shot_delay = 2.25
-	burst_shot_delay = 1.5
-	extra_penetration = 0.1
-	extra_damage = 3
+	automatic = FALSE
+	autofire_shot_delay = 2
+	burst_shot_delay = 0.5
 	can_attachments = TRUE
-	can_automatic = TRUE
 	semi_auto = TRUE
 	can_scope = FALSE
-	spread = 8
+	spread = 0
 	zoomable = TRUE
 	zoom_amt = 10
 	zoom_out_amt = 13
+	actions_types = list(/datum/action/item_action/toggle_firemode)
 
+/obj/item/gun/ballistic/automatic/g11/ui_action_click(mob/user, action)
+	if(istype(action, /datum/action/item_action/toggle_firemode))
+		burst_select()
+	else
+		return ..()
 
+/obj/item/gun/ballistic/automatic/g11/burst_select()
+	var/mob/living/carbon/human/user = usr
+	switch(select)
+		if(0)
+			select += 1
+			burst_size = 3
+			automatic = FALSE
+			burst_spread = 7.5
+			recoil = 0.25
+			to_chat(user, "<span class='notice'>You switch to burst fire.</span>")
+		if(1)
+			select += 1
+			burst_size = 1
+			automatic = TRUE
+			spread = 12.5
+			recoil = 0.5
+			to_chat(user, "<span class='notice'>You switch to full auto.</span>")
+		if(2)
+			select = 0
+			burst_size = 1
+			automatic = FALSE
+			spread = 0
+			recoil = 0
+			to_chat(user, "<span class='notice'>You switch to semi auto.</span>")
+	playsound(user, 'sound/weapons/empty.ogg', 100, 1)
+	update_icon()
+	return
 
 ////////////////
 //MACHINE-GUNS//

--- a/code/modules/projectiles/guns/ballistic/automatic.dm
+++ b/code/modules/projectiles/guns/ballistic/automatic.dm
@@ -615,7 +615,7 @@
 	is_automatic = TRUE
 	automatic = TRUE
 	extra_damage = 20
-	autofire_shot_delay = 2
+	autofire_shot_delay = 1.75
 	extra_penetration = 0.2
 	w_class = WEIGHT_CLASS_NORMAL
 	weapon_weight = WEAPON_MEDIUM

--- a/code/modules/projectiles/guns/ballistic/automatic.dm
+++ b/code/modules/projectiles/guns/ballistic/automatic.dm
@@ -1274,6 +1274,7 @@
 	fire_delay = 2
 	is_automatic = TRUE
 	automatic = FALSE
+	extra_penetration = 0.1
 	autofire_shot_delay = 2
 	burst_shot_delay = 0.5
 	can_attachments = TRUE

--- a/code/modules/projectiles/guns/ballistic/automatic.dm
+++ b/code/modules/projectiles/guns/ballistic/automatic.dm
@@ -1270,7 +1270,7 @@
 	item_state = "g11"
 	mag_type = /obj/item/ammo_box/magazine/m473
 	burst_size = 1
-	extra_damage = 20
+	extra_damage = 22.5
 	fire_delay = 2
 	is_automatic = TRUE
 	automatic = FALSE

--- a/code/modules/projectiles/guns/ballistic/automatic.dm
+++ b/code/modules/projectiles/guns/ballistic/automatic.dm
@@ -1285,6 +1285,7 @@
 	zoom_amt = 10
 	zoom_out_amt = 13
 	actions_types = list(/datum/action/item_action/toggle_firemode)
+	select = 0
 
 /obj/item/gun/ballistic/automatic/g11/ui_action_click(mob/user, action)
 	if(istype(action, /datum/action/item_action/toggle_firemode))
@@ -1296,7 +1297,7 @@
 	var/mob/living/carbon/human/user = usr
 	switch(select)
 		if(0)
-			select += 1]
+			select += 1
 			if(burst_improvement)
 				burst_size = 5
 			else

--- a/code/modules/projectiles/guns/ballistic/automatic.dm
+++ b/code/modules/projectiles/guns/ballistic/automatic.dm
@@ -1307,14 +1307,14 @@
 			automatic = TRUE
 			spread = 12.5
 			recoil = 0.5
-			to_chat(user, "<span class='notice'>You switch to full auto.</span>")
+			to_chat(user, "<span class='notice'>You switch to full-auto.</span>")
 		if(2)
 			select = 0
 			burst_size = 1
 			automatic = FALSE
 			spread = 0
 			recoil = 0
-			to_chat(user, "<span class='notice'>You switch to semi auto.</span>")
+			to_chat(user, "<span class='notice'>You switch to semi-auto.</span>")
 	playsound(user, 'sound/weapons/empty.ogg', 100, 1)
 	update_icon()
 	return

--- a/code/modules/projectiles/guns/ballistic/automatic.dm
+++ b/code/modules/projectiles/guns/ballistic/automatic.dm
@@ -609,7 +609,7 @@
 /obj/item/gun/ballistic/automatic/wt550
 	name = "WT-550"
 	desc = "A compact PDW derived from the G11, firing the same 4.73mm rounds."
-	item_state = "wt550"
+	item_state = "WT550"
 	mag_type = /obj/item/ammo_box/magazine/m473/small
 	burst_size = 1
 	is_automatic = TRUE

--- a/code/modules/projectiles/projectile/bullets/rifle.dm
+++ b/code/modules/projectiles/projectile/bullets/rifle.dm
@@ -205,8 +205,8 @@ heavy rifle calibers (12.7, 14mm, 7.62): Uranium, Contaminated, Incin
 	bare_wound_bonus = -10
 
 /obj/item/projectile/bullet/a473/rubber
-	name = "4.73 polyurethane bullet "
-	damage = 5
+	name = "4.73 polyurethane bullet"
+	damage = -20
 	stamina = 18
 	sharpness = SHARP_NONE
 	armour_penetration = 0.05
@@ -215,21 +215,30 @@ heavy rifle calibers (12.7, 14mm, 7.62): Uranium, Contaminated, Incin
 
 /obj/item/projectile/bullet/a473/incendiary
 	name = "4.73 tracer bullet"
-	damage = 15
+	damage = -10
 	armour_penetration = 0.1
 	var/fire_stacks = 3
 	zone_accuracy_factor = 100
 
+/obj/item/projectile/bullet/a473/incendiary/on_hit(atom/target, blocked = FALSE)
+	. = ..()
+	if(iscarbon(target))
+		var/mob/living/carbon/M = target
+		M.adjust_fire_stacks(fire_stacks)
+		M.IgniteMob()
+
 /obj/item/projectile/bullet/a473/uraniumtipped
 	name = "4.73 U-235 bullet"
-	damage = 15
+	damage = -10
 	armour_penetration = 0.3
 	irradiate = 300
 
 /obj/item/projectile/bullet/a473/dumdum
 	name = "4.73 flat-nose bullet"
-	damage = 20
-	armour_penetration = 0.1
+	damage = 5
+	supereffective_damage = 10
+	supereffective_faction = list("hostile", "ant", "supermutant", "deathclaw", "cazador", "raider", "china", "gecko", "wastebot")
+	armour_penetration = -0.2
 	wound_bonus = 20
 	bare_wound_bonus = 30
 
@@ -238,7 +247,31 @@ heavy rifle calibers (12.7, 14mm, 7.62): Uranium, Contaminated, Incin
 
 /obj/item/projectile/bullet/a473/explosive/on_hit(atom/target, blocked = FALSE)
 	..()
-	explosion(target, 0, 0, 1, 0, adminlog = FALSE, flame_range = 1)
+	if(prob(10))
+		explosion(target, 0, 0, 1, 1, adminlog = FALSE, flame_range = 0)
+	else
+		explosion(target, 0, 0, 0, 1, adminlog = FALSE, flame_range = 1) //no boom, just flame and flash
+
+/obj/item/projectile/bullet/a473/shock
+	name = "4.73mm shock bullet"
+	damage = -12 // -50% damage
+	wound_bonus = 0
+	sharpness = SHARP_NONE
+	var/energy_damage = 4
+
+/obj/item/projectile/bullet/a473/shock/on_hit(atom/target, blocked = FALSE)
+	..()
+	target.emp_act(5)//5 severity is very, very low
+	if(blocked != 100 && isliving(target))
+		var/mob/living/L = target
+		L.electrocute_act(energy_damage, "shock bullet", 1, SHOCK_NOGLOVES | SHOCK_NOSTUN)
+
+/obj/item/projectile/bullet/a473/hv
+	name = "4.73mm highvelocity bullet"
+	damage = -14 //about -60% damage for hitscan
+	hitscan = TRUE
+	wound_bonus = 0
+
 
 
 //////////////////////////

--- a/code/modules/research/designs/ammolathe_designs.dm
+++ b/code/modules/research/designs/ammolathe_designs.dm
@@ -535,6 +535,14 @@
 	build_path = /obj/item/ammo_box/magazine/m473/empty
 	category = list("initial", "Advanced Magazines")
 
+/datum/design/ammolathe/m473s
+	name = "empty wt550 magazine (4.73mm)"
+	id = "m473s"
+	materials = list(/datum/material/iron = 2000)
+	build_path = /obj/item/ammo_box/magazine/m473/small/empty
+	category = list("initial", "Advanced Magazines")
+
+
 /datum/design/ammolathe/m762ext
 	name = "empty extended rifle magazine (7.62x51)"
 	id = "m762ext"
@@ -582,9 +590,64 @@
 /datum/design/ammolathe/m473fmj
 	name = "4.73mm caseless ammo box"
 	id = "m473fmj"
-	materials = list(/datum/material/iron = 25000, /datum/material/blackpowder = 2000)
+	materials = list(/datum/material/iron = 20000, /datum/material/blackpowder = 2000)
 	build_path = /obj/item/ammo_box/m473
 	category = list("initial", "Advanced Ammo")
+
+/datum/design/ammolathe/m473rubber
+	name = "4.73mm caseless rubber ammo box"
+	id = "m473rubber"
+	materials = list(/datum/material/plastic = 12000, /datum/material/blackpowder = 1000)
+	build_path = /obj/item/ammo_box/m473/rubber
+	category = list("initial", "Advanced Ammo")
+
+/datum/design/ammolathe/m473incin
+	name = "4.73mm incendiary caseless ammo box"
+	id = "m473incin"
+	materials = list(/datum/material/iron = 20000, /datum/material/blackpowder = 3000)
+	build_path = /obj/item/ammo_box/m473/incendiary
+	category = list("initial", "Advanced Ammo")
+
+/datum/design/ammolathe/m473u235
+	name = "4.73mm uranium-tipped caseless ammo box"
+	id = "m473u235"
+	materials = list(/datum/material/titanium = 10000, /datum/material/uranium = 4000, /datum/material/blackpowder = 2000)
+	build_path = /obj/item/ammo_box/m473/uraniumtipped
+	category = list("initial", "Advanced Ammo")
+
+/datum/design/ammolathe/m473wound
+	name = "4.73mm flat-nose caseless ammo box"
+	id = "m473wound"
+	materials = list(/datum/material/iron = 12000,/datum/material/titanium = 2000, /datum/material/blackpowder = 2000)
+	build_path = /obj/item/ammo_box/m473/dumdum
+	category = list("initial", "Advanced Ammo")
+
+/datum/design/ammolathe/m473explosive
+	name = "4.73mm explosive caseless ammo box"
+	id = "m473explosive"
+	materials = list(/datum/material/iron = 24000, /datum/material/titanium = 10000, /datum/material/blackpowder = 10000)
+	build_path = /obj/item/ammo_box/m473/explosive
+	category = list("initial", "Advanced Ammo")
+
+/datum/design/ammolathe/m473esd
+	name = "4.73mm ESD caseless ammo box"
+	id = "m473esd"
+	materials = list(/datum/material/iron = 12000, /datum/material/gold = 2000, /datum/material/silver = 2000, /datum/material/titanium = 2000, /datum/material/blackpowder = 2000)
+	build_path = /obj/item/ammo_box/m473/shock
+	category = list("initial", "Advanced Ammo")
+
+/datum/design/ammolathe/m473hv
+	name = "4.73mm high-velocity caseless ammo box"
+	id = "m473hv"
+	materials = list(/datum/material/iron = 12000, /datum/material/titanium = 8000, /datum/material/blackpowder = 3000)
+	build_path = /obj/item/ammo_box/m473/hv
+	category = list("initial", "Advanced Ammo")
+
+
+
+
+
+
 
 /datum/design/ammolathe/a357ricochet
 	name = ".357 ricochet ammo"


### PR DESCRIPTION


## About The Pull Request

caseless guns cool
they have a niche: wt550 is nothing special, but gets most specialty ammo types
g11 is slightly worse statwise, with less pen, but a very fast 3-round burst

g11 ammo:
explosive: chance to blow shit up. if that fails, it sets shit on fire. generally worse than incin unless you're lucky
incin: sets shit on fire
HV: hitscan, lower damage to compensate.
wounding/dumdum/flatnose: negative AP, higher damage, higher damage vs mobs. dungeoooning ammo.
uranium: irradiates, less upfront damage
shock: armor-penetrating shock damage (5) in exchange for significantly lower upfront damage
rubber: you know what this does.

uranium and explosive are not in the roundstart pool

## Why It's Good For The Game

g11 is criminally unused, and wt550 is too. adding them to bos fits as they're the hightech faction. may add to loot pools and other factions tbd

## Pre-Merge Checklist

- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.



## Changelog
:cl:
add: G11 loadout for Head Paladin, WT550 loadout for Senior Paladin.
/:cl:
