### PR TITLE
minor arrow tweaks

### DIFF
--- a/code/datums/components/crafting/recipes/recipes_primal.dm
+++ b/code/datums/components/crafting/recipes/recipes_primal.dm
@@ -242,8 +242,7 @@
 	result = /obj/item/ammo_casing/caseless/arrow/burning
 	time = 30
 	reqs = list(/obj/item/ammo_casing/caseless/arrow = 1,
-				/obj/item/reagent_containers/food/drinks/bottle = 1,
-				/obj/item/reagent_containers/food/snacks/meat/slab/human/ghoul = 4)
+				/datum/reagent/fuel = 10)
 	category = CAT_TRIBAL
 	tools = list(TOOL_WORKBENCH)
 
@@ -273,7 +272,7 @@
 	time = 30
 	reqs = list(
 		/obj/item/ammo_casing/caseless/arrow = 1,
-		/obj/item/reagent_containers/food/snacks/grown/nettle = 5,
+		/obj/item/reagent_containers/food/snacks/grown/feracactus = 1,
 		)
 	category = CAT_TRIBAL
 	tools = list(TOOL_WORKBENCH)

--- a/code/modules/projectiles/projectile/reusable/arrow.dm
+++ b/code/modules/projectiles/projectile/reusable/arrow.dm
@@ -19,7 +19,7 @@
 	damage = 20
 	armour_penetration = 0.10
 	supereffective_damage = 40
-	supereffective_faction = list("hostile", "ant", "supermutant", "deathclaw", "cazador", "raider", "china", "gecko", "wastebot")
+	supereffective_faction = list("hostile", "ant", "supermutant", "deathclaw", "cazador", "raider", "china", "gecko", "wastebot","radscorpion")
 	ammo_type = /obj/item/ammo_casing/caseless/arrow/bone
 
 /obj/item/projectile/bullet/reusable/arrow/bronze //Just some AP shots

--- a/code/modules/projectiles/projectile/reusable/arrow.dm
+++ b/code/modules/projectiles/projectile/reusable/arrow.dm
@@ -83,7 +83,7 @@
 	damage = 20
 	sharpness = SHARP_EDGED
 	ammo_type = /obj/item/ammo_casing/caseless/arrow/broadhead
-	embedding = list(embed_chance=100, fall_chance=0, jostle_chance=3, ignore_throwspeed_threshold=TRUE, pain_stam_pct=0.2, pain_mult=3, jostle_pain_mult=5, rip_time=25, projectile_payload = /obj/item/ammo_casing/caseless/arrow/broadhead)
+	embedding = list(embed_chance=95, fall_chance=0, jostle_chance=3, ignore_throwspeed_threshold=TRUE, pain_stam_pct=0.2, pain_mult=3, jostle_pain_mult=5, rip_time=25, projectile_payload = /obj/item/ammo_casing/caseless/arrow/broadhead)
 
 /obj/item/projectile/bullet/reusable/arrow/broadhead/on_hit(atom/target, blocked)
 	if(iscarbon(target))


### PR DESCRIPTION
broadhead embed chance no longer 100, since 100 embed ignores armor deflect
burn and poison arrows cheaper

## Pre-Merge Checklist
- [ ] You tested this on a local server.
- [ ] This code did not runtime during testing.
- [ ] You documented all of your changes.


:cl:
balance: burn and toxin arrows cheaper, broadhead embed now respects armor
/:cl:
