### PR TITLE
9mm acid-tipped bullets can no longer deal tox damage

### DIFF
--- a/code/modules/projectiles/projectile/bullets/pistol.dm
+++ b/code/modules/projectiles/projectile/bullets/pistol.dm
@@ -153,7 +153,6 @@ Uranium, Contaminated
 	if(isliving(target))
 		var/mob/living/M = target
 		reagents.reaction(M, TOUCH)
-		reagents.trans_to(M, reagents.total_volume)
 
 /obj/item/projectile/bullet/c9mm/incendiary
 	name = "9mm incendiary bullet"


### PR DESCRIPTION


## Why It's Good For The Game
acid bullets shouldn't really be doing this, it's an unintended interaction between liver toxin purge, automatic firerate and how acids work

.38, .357 and .4570 i'm still fine with doing toxin, as .38/4570 don't have any automatic weapons and .357 only has the autopipe

## Pre-Merge Checklist
- [ ] You tested this on a local server.
- [ ] This code did not runtime during testing.
- [ ] You documented all of your changes.



## Changelog
:cl:
balance: acid bullets (9mm)
/:cl:


